### PR TITLE
Extend logger interface

### DIFF
--- a/src/BigQuerier.sln.DotSettings
+++ b/src/BigQuerier.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MemberCanBePrivate_002EGlobal/@EntryIndexedValue">HINT</s:String></wpf:ResourceDictionary>

--- a/src/Trafi.BigQuerier.Tests/Mapper/PrimitiveFieldTest.cs
+++ b/src/Trafi.BigQuerier.Tests/Mapper/PrimitiveFieldTest.cs
@@ -139,7 +139,7 @@ namespace Trafi.BigQuerier.Tests.Mapper
             {
                 bigQueryValue = fieldToBigQuery(value);
                 bigQueryValue
-                    .ShouldBeEquivalentTo(expectedBigQueryValue,
+                    .Should().BeEquivalentTo(expectedBigQueryValue,
                         $"{type} value {value} should be {expectedBigQueryValue} when converted to big query value");
             }
             else
@@ -155,7 +155,7 @@ namespace Trafi.BigQuerier.Tests.Mapper
             }
             else
             {
-                valueAgain.Value.ShouldBeEquivalentTo(expectedValueAgain.Value,
+                valueAgain.Value.Should().BeEquivalentTo(expectedValueAgain.Value,
                     $"Should set {type} value {bigQueryValue} to {expectedValueAgain.Value} when converting from big query");
             }
         }
@@ -304,7 +304,7 @@ namespace Trafi.BigQuerier.Tests.Mapper
             {
                 bigQueryValue = fieldToBigQuery(value);
                 bigQueryValue
-                    .ShouldBeEquivalentTo(expectedBigQueryValue);
+                    .Should().BeEquivalentTo(expectedBigQueryValue);
             }
             else
             {
@@ -317,7 +317,7 @@ namespace Trafi.BigQuerier.Tests.Mapper
             }
             else
             {
-                fieldFromBigQuery(bigQueryValue).Value.ShouldBeEquivalentTo(expectedValueAgain.Value);
+                fieldFromBigQuery(bigQueryValue).Value.Should().BeEquivalentTo(expectedValueAgain.Value);
             }
         }
 

--- a/src/Trafi.BigQuerier.Tests/Trafi.BigQuerier.Tests.csproj
+++ b/src/Trafi.BigQuerier.Tests/Trafi.BigQuerier.Tests.csproj
@@ -1,22 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>9</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions">
-      <Version>4.19.4</Version>
-    </PackageReference>
-    <PackageReference Include="NUnit">
-      <Version>3.7.1</Version>
-    </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NUnitLite">
-      <Version>3.7.2</Version>
-    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="NUnitLite" Version="4.2.2" />
+    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.40" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Trafi.BigQuerier/Dispatcher/IDispatchLogger.cs
+++ b/src/Trafi.BigQuerier/Dispatcher/IDispatchLogger.cs
@@ -17,5 +17,13 @@ namespace Trafi.BigQuerier.Dispatcher
         void InsertError(Exception ex, BigQueryInsertRow[] insertRows, string traceId);
         void UnsentRows(BigQueryInsertRow[] insertRows);
         void CannotAdd(BigQueryInsertRow row);
+        /// <summary>
+        /// Called after a batch is stored
+        /// </summary>
+        /// <param name="stored">Stored items count</param>
+        /// <param name="timeTakenMs">Time taken to Store the batch in milliseconds</param>
+        /// <param name="remainingInQueue">Items remaining in queue</param>
+        /// <param name="traceId">TraceId, unique per Storage attempt</param>
+        void Stored(int stored, int timeTakenMs, int remainingInQueue, string traceId);
     }
 }

--- a/src/Trafi.BigQuerier/Trafi.BigQuerier.csproj
+++ b/src/Trafi.BigQuerier/Trafi.BigQuerier.csproj
@@ -1,20 +1,31 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <PackageId>Trafi.BigQuerier</PackageId>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageVersion>1.0.0</PackageVersion>
-    <LangVersion>8</LangVersion>
+  <PropertyGroup>    
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>CS8600;CS8604;CS8602;CS8625;CS8632;CS8603;CS8618;CS8619;CS8767;CS8613;CS8601;CS8620</WarningsAsErrors>
+  </PropertyGroup>
 
+  <PropertyGroup>
+    <PackageId>Trafi.BigQuerier</PackageId>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <AssemblyVersion>1.0.0</AssemblyVersion>
+    <PackageVersion>1.0.0</PackageVersion>
+    <FileVersion>1.0.0</FileVersion>
     <Authors>Trafi</Authors>
     <Copyright>2021 TRAFI</Copyright>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageProjectUrl>https://github.com/trafi/big-querier</PackageProjectUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/trafi/big-querier/master/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/trafi/big-querier</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/trafi/big-querier</PackageProjectUrl>
+    <PackageLicenseUrl>https://raw.githubusercontent.com/trafi/big-querier/master/LICENSE</PackageLicenseUrl>
+    <DebugType>Embedded</DebugType>
+    <EmbedAllSources>True</EmbedAllSources>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <!-- This disables compiler warnings when not all public members are documented -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Google.Apis.Auth" Version="1.54.0" />
     <PackageReference Include="Google.Cloud.BigQuery.V2" Version="2.3.0" />


### PR DESCRIPTION
- Update to net6
- Add nuget package props like on other packages of ours
- Extend `IDispatchLogger` with `Stored` to expose current queue metrics