### PR TITLE
Enable DispatcherService to dispatch batches concurrently

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,22 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+root = true
+
+# All files
+[*]
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.json]
+indent_style = space
+indent_size = 2
+
+[*.csproj]
+indent_style = space
+indent_size = 2
+
+[*.cs]
+indent_style = space
+indent_size = 4

--- a/src/BigQuerier.sln.DotSettings
+++ b/src/BigQuerier.sln.DotSettings
@@ -1,2 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MemberCanBePrivate_002EGlobal/@EntryIndexedValue">HINT</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MemberCanBePrivate_002EGlobal/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantAnonymousTypePropertyName/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantDefaultMemberInitializer/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedMember_002EGlobal/@EntryIndexedValue">HINT</s:String></wpf:ResourceDictionary>

--- a/src/Trafi.BigQuerier.Tests/DispatcherServiceTests.cs
+++ b/src/Trafi.BigQuerier.Tests/DispatcherServiceTests.cs
@@ -1,0 +1,265 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Google.Apis.Bigquery.v2.Data;
+using Google.Cloud.BigQuery.V2;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using NUnit.Framework;
+using Trafi.BigQuerier.Dispatcher;
+
+namespace Trafi.BigQuerier.Tests;
+
+public class DispatcherServiceTests
+{
+    private FakeTimeProvider _timeProvider = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _timeProvider = new FakeTimeProvider();
+        _timeProvider.SetUtcNow(new DateTimeOffset(2024, 01, 01, 00, 00, 00, TimeSpan.Zero));
+    }
+
+    [Test]
+    public async Task GivenMoreRowsThanCanFitIntoBatchesOfAvailableWorkers_RemainingRowsAreHandledOnceAWorkerIsFreed()
+    {
+        var (bigQueryClientMock, bigQueryTableClientMock, _) =
+            SetupClients(TimeSpan.FromSeconds(60), _timeProvider);
+
+        var dispatcher = new DispatcherService(bigQueryClientMock.Object, new TableSchema(), "datasetId", dt => $"r{dt.Date:yyyyMMdd}",
+            batchSize: 10,
+            concurrentDispatches: 3);
+        DispatcherService.TestAccessor.SetTimeProvider(dispatcher, _timeProvider);
+        await Task.Delay(100);
+
+        // At this point RunInternalDispatch is pausing for 2 seconds
+
+        // Four batches worth of rows added
+        // Adding more than a batche's worth of rows cancels the waiting period
+        DispatchRows(dispatcher, 33);
+        await Task.Delay(100);
+
+        // 3 workers have picked up 10 rows each
+        VerifyInsertedRows(bigQueryTableClientMock, numberOfRows: 10, numberOfTimes: 3);
+        bigQueryTableClientMock.VerifyNoOtherCalls();
+
+        // Inserting is configured to last 60 seconds so nothing happens after the pause
+        _timeProvider.Advance(TimeSpan.FromSeconds(3));
+        await Task.Delay(100);
+        bigQueryTableClientMock.VerifyNoOtherCalls();
+
+        // Insert succeeded, 3 workers are ready to pick up work
+        _timeProvider.Advance(TimeSpan.FromSeconds(60));
+        await Task.Delay(100);
+
+        // Remaining 3 rows are taken into a single batch
+        VerifyInsertedRows(bigQueryTableClientMock, numberOfRows: 3, numberOfTimes: 1);
+        bigQueryTableClientMock.VerifyNoOtherCalls();
+
+        // Make sure nothing else happens after all 33 rows have been dispatched
+        _timeProvider.Advance(TimeSpan.FromSeconds(100));
+        await Task.Delay(100);
+        bigQueryTableClientMock.VerifyNoOtherCalls();
+    }
+
+    [Test]
+    public async Task Dispose_WhenThereAreManyRowsToDispatch_ExitsPauseBetweenRuns()
+    {
+        var (bigQueryClientMock, bigQueryTableClientMock, _) =
+            SetupClients(TimeSpan.Zero, _timeProvider);
+
+        var loggerMock = new Mock<IDispatchLogger>();
+
+        var dispatcher = new DispatcherService(bigQueryClientMock.Object, new TableSchema(), "datasetId", dt => $"r{dt.Date:yyyyMMdd}",
+            logger: loggerMock.Object,
+            batchSize: 10,
+            concurrentDispatches: 3);
+        DispatcherService.TestAccessor.SetTimeProvider(dispatcher, _timeProvider);
+        await Task.Delay(100);
+
+        // At this point RunInternalDispatch is pausing for 2 seconds
+
+        // Seven batches worth of rows added
+        DispatchRows(dispatcher, 66);
+
+        // Act - stopping during pause between runs
+        var disposeTask = Task.Run(() => dispatcher.Dispose());
+
+        await Task.Delay(100);
+
+        // Notice we didn't move the clock forward for 2 seconds to exit the pause.
+        // The dispatcher should exit the pause when disposed to complate as much work as possible.
+
+        // 3 workers have picked up 3*10*2+6 rows
+        VerifyInsertedRows(bigQueryTableClientMock, numberOfRows: 10, numberOfTimes: 6);
+        VerifyInsertedRows(bigQueryTableClientMock, numberOfRows: 6, numberOfTimes: 1);
+        bigQueryTableClientMock.VerifyNoOtherCalls();
+
+        await disposeTask;
+
+        loggerMock.Verify(l => l.WaitForEnd(), Times.Once);
+        loggerMock.Verify(l => l.UnsentRows(It.IsAny<BigQueryInsertRow[]>()), Times.Never);
+
+        var remainingDispatchTasks = DispatcherService.TestAccessor.GetDispatchToBigQueryTasks(dispatcher);
+        Assert.That(remainingDispatchTasks.Count, Is.Zero);
+    }
+
+    [Test]
+    public async Task GivenRowsFromDifferentDays_TheyAreInsertedIntoCorrespondingTables()
+    {
+        var (bigQueryClientMock, bigQueryTable0101ClientMock, bigQueryTable0102ClientMock) =
+            SetupClients(TimeSpan.Zero, _timeProvider);
+
+        var dispatcher = new DispatcherService(bigQueryClientMock.Object, new TableSchema(), "datasetId", dt => $"r{dt.Date:yyyyMMdd}",
+            batchSize: 10,
+            concurrentDispatches: 1);
+        DispatcherService.TestAccessor.SetTimeProvider(dispatcher, _timeProvider);
+        await Task.Delay(100);
+
+        // At this point RunInternalDispatch is pausing for 2 seconds
+
+        // Batch 1: 7 rows for 2024-01-01 3 rows for 2024-01-02
+        // Batch 2: 8 rows for 2024-01-01 2 rows for 2024-01-02
+        DispatchRows(dispatcher, 7);
+        DispatchRows(dispatcher, 5, _timeProvider.GetUtcNow().DateTime.AddDays(1));
+        DispatchRows(dispatcher, 8);
+
+        // Finishing the pause
+        _timeProvider.Advance(TimeSpan.FromSeconds(3));
+        await Task.Delay(100);
+
+        // 3 workers have picked up 10 rows each
+        VerifyInsertedRows(bigQueryTable0101ClientMock, numberOfRows: 7, numberOfTimes: 1);
+        VerifyInsertedRows(bigQueryTable0102ClientMock, numberOfRows: 3, numberOfTimes: 1);
+        VerifyInsertedRows(bigQueryTable0102ClientMock, numberOfRows: 2, numberOfTimes: 1);
+        VerifyInsertedRows(bigQueryTable0101ClientMock, numberOfRows: 8, numberOfTimes: 1);
+        bigQueryTable0101ClientMock.VerifyNoOtherCalls();
+        bigQueryTable0102ClientMock.VerifyNoOtherCalls();
+
+        // Make sure nothing else happens after all 33 rows have been dispatched
+        _timeProvider.Advance(TimeSpan.FromSeconds(100));
+        await Task.Delay(100);
+        bigQueryTable0101ClientMock.VerifyNoOtherCalls();
+        bigQueryTable0102ClientMock.VerifyNoOtherCalls();
+    }
+
+    [Test]
+    public async Task GivenMoreRowsThanCanFitInAQueue_OverflowRowsAreDropped()
+    {
+        var (bigQueryClientMock, bigQueryTableClientMock, _) =
+            SetupClients(TimeSpan.FromSeconds(60), _timeProvider);
+
+        var loggerMock = new Mock<IDispatchLogger>();
+
+        var dispatcher = new DispatcherService(bigQueryClientMock.Object, new TableSchema(),
+            "datasetId", dt => $"r{dt.Date:yyyyMMdd}",
+            logger: loggerMock.Object,
+            batchSize: 10,
+            maxQueueLength: 100,
+            concurrentDispatches: 3);
+        DispatcherService.TestAccessor.SetTimeProvider(dispatcher, _timeProvider);
+        await Task.Delay(100);
+
+        // At this point RunInternalDispatch is pausing for 2 seconds
+
+        // Four batches worth of rows added
+        DispatchRows(dispatcher, 33);
+        await Task.Delay(100);
+
+        // 3 workers have picked up 10 rows each
+        VerifyInsertedRows(bigQueryTableClientMock, numberOfRows: 10, numberOfTimes: 3);
+        bigQueryTableClientMock.VerifyNoOtherCalls();
+
+        // There are 3 rows left in the queue at this moment, 3 should be dropped
+        DispatchRows(dispatcher, 100);
+        await Task.Delay(200);
+
+        loggerMock.Verify(l => l.CannotAdd(It.IsAny<BigQueryInsertRow>()), Times.Exactly(3));
+        Assert.That(dispatcher.QueueSize, Is.EqualTo(100));
+    }
+
+    [Test]
+    public async Task GivenTableNameResolverFuncThatThrows_ErrorsAreReportedToLogger()
+    {
+        var (bigQueryClientMock, bigQueryTable0101ClientMock, bigQueryTable0102ClientMock) =
+            SetupClients(TimeSpan.Zero, _timeProvider);
+
+        static string ThrowingTableNameResolver(DateTime d) =>
+            d.Day == 1 ? "r20240101" : throw new Exception("Test exception");
+
+        var loggerMock = new Mock<IDispatchLogger>();
+
+        var dispatcher = new DispatcherService(bigQueryClientMock.Object, new TableSchema(), "datasetId",
+            ThrowingTableNameResolver,
+            logger: loggerMock.Object,
+            batchSize: 10,
+            concurrentDispatches: 2);
+        DispatcherService.TestAccessor.SetTimeProvider(dispatcher, _timeProvider);
+        await Task.Delay(100);
+
+        // At this point RunInternalDispatch is pausing for 2 seconds
+
+        // Batch 1: 10 rows for 2024-01-01
+        // Batch 2: 2 rows for 2024-01-01 3 rows for 2024-01-02
+        DispatchRows(dispatcher, 12);
+        DispatchRows(dispatcher, 3, _timeProvider.GetUtcNow().DateTime.AddDays(1));
+
+        // Finishing the pause to prcess the first batch
+        _timeProvider.Advance(TimeSpan.FromSeconds(3));
+        await Task.Delay(100);
+        // Since second batch is not full a pause is active
+        _timeProvider.Advance(TimeSpan.FromSeconds(3));
+        await Task.Delay(100);
+
+        VerifyInsertedRows(bigQueryTable0101ClientMock, numberOfRows: 10, numberOfTimes: 1);
+        VerifyInsertedRows(bigQueryTable0102ClientMock, numberOfRows: null, numberOfTimes: 0);
+        bigQueryTable0101ClientMock.VerifyNoOtherCalls();
+        bigQueryTable0102ClientMock.VerifyNoOtherCalls();
+
+        loggerMock.Verify(l => l.InsertError(
+            It.Is<Exception>(e => e.Message == "Test exception"),
+            It.Is<BigQueryInsertRow[]>(r => r.Length == 5),
+            It.Is<string>(a => Guid.Parse(a) != Guid.Empty)), Times.Exactly(1));
+
+        // Make sure nothing else happens
+        _timeProvider.Advance(TimeSpan.FromSeconds(100));
+        await Task.Delay(100);
+        bigQueryTable0101ClientMock.VerifyNoOtherCalls();
+        bigQueryTable0102ClientMock.VerifyNoOtherCalls();
+    }
+
+    private void DispatchRows(DispatcherService dispatcher, int count, DateTime? date = null)
+    {
+        date ??= _timeProvider.GetUtcNow().DateTime;
+
+        for (int i = 0; i < count; i++)
+            dispatcher.Dispatch(date.Value, new BigQueryInsertRow());
+    }
+
+    private (Mock<IBigQueryClient>, Mock<IBigQueryTableClient>, Mock<IBigQueryTableClient>) SetupClients(TimeSpan delay, TimeProvider timeProvider)
+    {
+        var bigQueryTable0101ClientMock = new Mock<IBigQueryTableClient>();
+        bigQueryTable0101ClientMock.Setup(c => c.InsertRows(It.IsAny<BigQueryInsertRow[]>(), It.IsAny<CancellationToken>()))
+            .Returns(() => Task.Delay(delay, timeProvider));
+        var bigQueryTable0102ClientMock = new Mock<IBigQueryTableClient>();
+        bigQueryTable0102ClientMock.Setup(c => c.InsertRows(It.IsAny<BigQueryInsertRow[]>(), It.IsAny<CancellationToken>()))
+            .Returns(() => Task.Delay(delay, timeProvider));
+
+        var bigQueryClientMock = new Mock<IBigQueryClient>();
+        bigQueryClientMock.Setup(c => c.GetTableClient("datasetId", "r20240101", It.IsAny<TableSchema>(), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(bigQueryTable0101ClientMock.Object);
+        bigQueryClientMock.Setup(c => c.GetTableClient("datasetId", "r20240102", It.IsAny<TableSchema>(), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(bigQueryTable0102ClientMock.Object);
+
+        return (bigQueryClientMock, bigQueryTable0101ClientMock, bigQueryTable0102ClientMock);
+    }
+
+    private static void VerifyInsertedRows(Mock<IBigQueryTableClient> mock, int? numberOfRows, int numberOfTimes)
+    {
+        mock.Verify(c => c.InsertRows(
+                It.Is<BigQueryInsertRow[]>(r => numberOfRows == null || r.Length == numberOfRows),
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(numberOfTimes));
+    }
+}

--- a/src/Trafi.BigQuerier.Tests/Mapper/PrimitiveFieldTest.cs
+++ b/src/Trafi.BigQuerier.Tests/Mapper/PrimitiveFieldTest.cs
@@ -4,325 +4,324 @@ using System;
 using System.Collections.Generic;
 using Trafi.BigQuerier.Mapper;
 
-namespace Trafi.BigQuerier.Tests.Mapper
+namespace Trafi.BigQuerier.Tests.Mapper;
+
+[TestFixture]
+public class PrimitiveFieldTest
 {
-    [TestFixture]
-    public class PrimitiveFieldTest
+    [QuerierContract]
+    private class With<T>
     {
-        [QuerierContract]
-        private class With<T>
-        {
-            public T Prop { get; set; }
-        }
-
-        [QuerierContract]
-        private class WithArray<T>
-        {
-            public T[] Prop { get; set; }
-        }
-
-        #region Simple Field
-
-        #region Simple Field Schema
-
-        private static TestCaseData MakeSchemaFieldTestCase<T>(string bigQueryType)
-        {
-            return new TestCaseData(bigQueryType, Contract<With<T>>.Create().Cache)
-            {
-                TestName = $"{typeof(T)} fields should be {bigQueryType} in schema"
-            };
-        }
-
-        private static IEnumerable<TestCaseData> AddSchemaFieldTestCases()
-        {
-            yield return MakeSchemaFieldTestCase<string>("STRING");
-            yield return MakeSchemaFieldTestCase<long>("INTEGER");
-            yield return MakeSchemaFieldTestCase<long?>("INTEGER");
-            yield return MakeSchemaFieldTestCase<int>("INTEGER");
-            yield return MakeSchemaFieldTestCase<int?>("INTEGER");
-            yield return MakeSchemaFieldTestCase<double>("FLOAT");
-            yield return MakeSchemaFieldTestCase<double?>("FLOAT");
-            yield return MakeSchemaFieldTestCase<DateTime>("TIMESTAMP");
-            yield return MakeSchemaFieldTestCase<DateTime?>("TIMESTAMP");
-            yield return MakeSchemaFieldTestCase<bool>("BOOLEAN");
-            yield return MakeSchemaFieldTestCase<bool?>("BOOLEAN");
-        }
-
-        [Test, TestCaseSource(nameof(AddSchemaFieldTestCases))]
-        public void SchemaFieldTypeShouldBeCorrect(string bigQueryType, ContractCache contract)
-        {
-            contract.Schema.Fields.Should().HaveCount(1);
-            contract.Schema.Fields[0].Name.Should().Be("Prop");
-            contract.Schema.Fields[0].Mode.Should().Be("NULLABLE");
-            contract.Schema.Fields[0].Type.Should().Be(bigQueryType);
-        }
-
-        #endregion
-
-        #region Simple Field Mapping
-
-        private static TestCaseData MakeFieldMappingTestCase<TApp, TBigQuery>(TApp appValue, TBigQuery bigQueryValue,
-            bool fetchOnly, bool shouldSkip)
-        {
-            var type = typeof(TApp);
-            var caseMessage = fetchOnly ? "work for select" : "work for insert and select";
-            return new TestCaseData(type, appValue, bigQueryValue,
-                new Value.MapResult {Value = appValue, Skip = shouldSkip}, fetchOnly)
-            {
-                TestName = $"{typeof(TApp)} field mapping should {caseMessage}"
-            };
-        }
-
-        private static IEnumerable<TestCaseData> AddFieldMappingTestCases()
-        {
-            yield return MakeFieldMappingTestCase<string, string>
-                (appValue: "Hello", bigQueryValue: "Hello", fetchOnly: false, shouldSkip: false);
-            yield return MakeFieldMappingTestCase<string, int>
-                (appValue: "Hello", bigQueryValue: 123, fetchOnly: true, shouldSkip: true);
-
-            yield return MakeFieldMappingTestCase<long, long>
-                (appValue: 123, bigQueryValue: 123, fetchOnly: false, shouldSkip: false);
-            yield return MakeFieldMappingTestCase<long, string>
-                (appValue: 123, bigQueryValue: "garbage", fetchOnly: true, shouldSkip: true);
-            yield return MakeFieldMappingTestCase<long?, long?>
-                (appValue: 123, bigQueryValue: 123, fetchOnly: false, shouldSkip: false);
-            yield return MakeFieldMappingTestCase<long?, string>
-                (appValue: 123, bigQueryValue: "garbage", fetchOnly: true, shouldSkip: true);
-            yield return MakeFieldMappingTestCase<long?, long>
-                (appValue: 123, bigQueryValue: 123, fetchOnly: false, shouldSkip: false);
-            yield return MakeFieldMappingTestCase<long, long?>
-                (appValue: 123, bigQueryValue: 123, fetchOnly: false, shouldSkip: false);
-
-            
-            yield return MakeFieldMappingTestCase<int, string>
-                (appValue: 123, bigQueryValue: "garbage", fetchOnly: true, shouldSkip: true);
-            yield return MakeFieldMappingTestCase<int?, string>
-                (appValue: 123, bigQueryValue: "garbage", fetchOnly: true, shouldSkip: true);
-            yield return MakeFieldMappingTestCase<int, long>
-                (appValue: 123, bigQueryValue: 123, fetchOnly: true, shouldSkip: false);
-            yield return MakeFieldMappingTestCase<int, long>
-                (appValue: 123, bigQueryValue: long.MaxValue, fetchOnly: true, shouldSkip: true);
-            yield return MakeFieldMappingTestCase<int?, long>
-                (appValue: 123, bigQueryValue: 123, fetchOnly: false, shouldSkip: false);
-            yield return MakeFieldMappingTestCase<int?, long?>
-                (appValue: 123, bigQueryValue: 123, fetchOnly: false, shouldSkip: false);
-            yield return MakeFieldMappingTestCase<int, long?>
-                (appValue: 123, bigQueryValue: 123, fetchOnly: false, shouldSkip: false);
-
-            yield return MakeFieldMappingTestCase<double, double>
-                (appValue: 123, bigQueryValue: 123, fetchOnly: false, shouldSkip: false);
-            yield return MakeFieldMappingTestCase<double, string>
-                (appValue: 123, bigQueryValue: "garbage", fetchOnly: true, shouldSkip: true);
-
-            yield return MakeFieldMappingTestCase<DateTime, DateTime>
-            (appValue: DateTime.Parse("2018-03-04 18:23:45"),
-                bigQueryValue: DateTime.Parse("2018-03-04 18:23:45"), fetchOnly: false, shouldSkip: false);
-            yield return MakeFieldMappingTestCase<DateTime, string>
-            (appValue: DateTime.Parse("2018-03-04 18:23:45"),
-                bigQueryValue: "garbage", fetchOnly: true, shouldSkip: true);
-
-            yield return MakeFieldMappingTestCase<bool, bool>
-                (appValue: true, bigQueryValue: true, fetchOnly: false, shouldSkip: false);
-            yield return MakeFieldMappingTestCase<bool, string>
-                (appValue: true, bigQueryValue: "garbage", fetchOnly: true, shouldSkip: true);
-        }
-
-        [Test, TestCaseSource(nameof(AddFieldMappingTestCases))]
-        public void FieldMappedValueShouldBeCorrect(Type type, object value, object expectedBigQueryValue,
-            Value.MapResult expectedValueAgain, bool fetchOnly)
-        {
-            var fieldToBigQuery = Value.MaybeFieldToBigQueryFunction(type);
-            var fieldFromBigQuery = Value.MaybeFieldFromBigQueryFunction(type);
-
-            object bigQueryValue;
-            if (!fetchOnly)
-            {
-                bigQueryValue = fieldToBigQuery(value);
-                bigQueryValue
-                    .Should().BeEquivalentTo(expectedBigQueryValue,
-                        $"{type} value {value} should be {expectedBigQueryValue} when converted to big query value");
-            }
-            else
-            {
-                bigQueryValue = expectedBigQueryValue;
-            }
-
-            var valueAgain = fieldFromBigQuery(bigQueryValue);
-            if (expectedValueAgain.Skip)
-            {
-                valueAgain.Skip.Should()
-                    .BeTrue($"Should skip setting {type} value {bigQueryValue} when converting from big query");
-            }
-            else
-            {
-                valueAgain.Value.Should().BeEquivalentTo(expectedValueAgain.Value,
-                    $"Should set {type} value {bigQueryValue} to {expectedValueAgain.Value} when converting from big query");
-            }
-        }
-
-        #endregion
-
-        #endregion
-
-        #region Simple field with Array values
-
-        #region Simple field with Array values schema
-
-        private static TestCaseData MakeSchemaArrayFieldTestCase<T>(string bigQueryType)
-        {
-            return new TestCaseData(bigQueryType, Contract<WithArray<T>>.Create().Cache)
-            {
-                TestName = $"{typeof(T)} array fields should be REPEATED in schema and have {bigQueryType} type"
-            };
-        }
-
-        private static IEnumerable<TestCaseData> AddSchemaArrayFieldTestCases()
-        {
-            yield return MakeSchemaArrayFieldTestCase<string>("STRING");
-            yield return MakeSchemaArrayFieldTestCase<long>("INTEGER");
-            yield return MakeSchemaArrayFieldTestCase<long?>("INTEGER");
-            yield return MakeSchemaArrayFieldTestCase<int>("INTEGER");
-            yield return MakeSchemaArrayFieldTestCase<int?>("INTEGER");
-            yield return MakeSchemaArrayFieldTestCase<double>("FLOAT");
-            yield return MakeSchemaArrayFieldTestCase<double?>("FLOAT");
-            yield return MakeSchemaArrayFieldTestCase<DateTime>("TIMESTAMP");
-            yield return MakeSchemaArrayFieldTestCase<DateTime?>("TIMESTAMP");
-            yield return MakeSchemaArrayFieldTestCase<bool>("BOOLEAN");
-            yield return MakeSchemaArrayFieldTestCase<bool?>("BOOLEAN");
-        }
-
-        [Test, TestCaseSource(nameof(AddSchemaArrayFieldTestCases))]
-        public void SchemaArrayFieldTypeShouldBeCorrect(string bigQueryType, ContractCache contract)
-        {
-            contract.Schema.Fields.Should().HaveCount(1);
-            contract.Schema.Fields[0].Name.Should().Be("Prop");
-            contract.Schema.Fields[0].Mode.Should().Be("REPEATED");
-            contract.Schema.Fields[0].Type.Should().Be(bigQueryType);
-        }
-
-        #endregion
-
-        #region Simple Field Mapping
-
-        private static TestCaseData MakeArrayFieldMappingTestCase<TApp, TBigQuery>(TApp[] appValue,
-            TBigQuery[] bigQueryValue, bool fetchOnly, bool shouldSkip)
-        {
-            var type = typeof(TApp);
-            return new TestCaseData(type, appValue, bigQueryValue,
-                new Value.MapResult {Value = appValue, Skip = shouldSkip}, fetchOnly)
-            {
-                TestName = $"{type} array field mapping should work for insert and select"
-            };
-        }
-
-        private static IEnumerable<TestCaseData> AddArrayFieldMappingTestCases()
-        {
-            yield return MakeArrayFieldMappingTestCase<string, string>
-                (appValue: new[] {"Hello"}, bigQueryValue: new[] {"Hello"}, fetchOnly: false, shouldSkip: false);
-            yield return MakeArrayFieldMappingTestCase<string, long>
-                (appValue: new string[] { }, bigQueryValue: new long[] {123}, fetchOnly: true, shouldSkip: true);
-
-            yield return MakeArrayFieldMappingTestCase<long, long>
-            (appValue: new long[] {42, 123}, bigQueryValue: new long[] {42, 123}, fetchOnly: false,
-                shouldSkip: false);
-            yield return MakeArrayFieldMappingTestCase<long, bool>
-                (appValue: new long[] {42, 123}, bigQueryValue: new bool[] {true}, fetchOnly: true, shouldSkip: true);
-            yield return MakeArrayFieldMappingTestCase<long?, long?>
-            (appValue: new long?[] {42, null, 123}, bigQueryValue: new long?[] {42, null, 123}, fetchOnly: false,
-                shouldSkip: false);
-            yield return MakeArrayFieldMappingTestCase<long?, bool?>
-                (appValue: new long?[] {42, 123}, bigQueryValue: new bool?[] {true}, fetchOnly: true, shouldSkip: true);
-            yield return MakeArrayFieldMappingTestCase<long, long?>
-            (appValue: new long[] {42, 123}, bigQueryValue: new long?[] {42, 123}, fetchOnly: false,
-                shouldSkip: false);
-            yield return MakeArrayFieldMappingTestCase<long?, long>
-            (appValue: new long?[] {42, 123}, bigQueryValue: new long[] {42, 123}, fetchOnly: false,
-                shouldSkip: false);
-
-            yield return MakeArrayFieldMappingTestCase<int, long>
-            (appValue: new int[] { 42, 123 }, bigQueryValue: new long[] { 42, 123 }, fetchOnly: false,
-                shouldSkip: false);
-            yield return MakeArrayFieldMappingTestCase<int, bool>
-                (appValue: new int[] { 42, 123 }, bigQueryValue: new bool[] { true }, fetchOnly: true, shouldSkip: true);
-            yield return MakeArrayFieldMappingTestCase<int?, long?>
-            (appValue: new int?[] { 42, null, 123 }, bigQueryValue: new long?[] { 42, null, 123 }, fetchOnly: false,
-                shouldSkip: false);
-            yield return MakeArrayFieldMappingTestCase<int?, bool?>
-                (appValue: new int?[] { 42, 123 }, bigQueryValue: new bool?[] { true }, fetchOnly: true, shouldSkip: true);
-            yield return MakeArrayFieldMappingTestCase<int, long?>
-            (appValue: new int[] { 42, 123 }, bigQueryValue: new long?[] { 42, 123 }, fetchOnly: false,
-                shouldSkip: false);
-            yield return MakeArrayFieldMappingTestCase<int?, long>
-            (appValue: new int?[] { 42, 123 }, bigQueryValue: new long[] { 42, 123 }, fetchOnly: false,
-                shouldSkip: false);
-            yield return MakeArrayFieldMappingTestCase<int?, long>
-            (appValue: new int?[] { 42, 123 }, bigQueryValue: new long[] { 42, long.MaxValue }, fetchOnly: true,
-                shouldSkip: true);
-
-
-
-            yield return MakeArrayFieldMappingTestCase<double, double>
-            (appValue: new double[] {42, 123}, bigQueryValue: new double[] {42, 123}, fetchOnly: false,
-                shouldSkip: false);
-            yield return MakeArrayFieldMappingTestCase<double, bool>
-                (appValue: new double[] {42, 123}, bigQueryValue: new bool[] {true}, fetchOnly: true, shouldSkip: true);
-
-            yield return MakeArrayFieldMappingTestCase<DateTime, DateTime>
-            (appValue: new DateTime[]
-            {
-                DateTime.Parse("2019-11-10 11:23:11"),
-                DateTime.Parse("2019-11-10 11:23:12")
-            }, bigQueryValue: new DateTime[]
-            {
-                DateTime.Parse("2019-11-10 11:23:11"),
-                DateTime.Parse("2019-11-10 11:23:12")
-            }, fetchOnly: false, shouldSkip: false);
-            yield return MakeArrayFieldMappingTestCase<DateTime, bool>
-            (appValue: new DateTime[]
-            {
-                DateTime.Parse("2019-11-10 11:23:11"),
-                DateTime.Parse("2019-11-10 11:23:12")
-            }, bigQueryValue: new bool[] {true}, fetchOnly: true, shouldSkip: true);
-
-            yield return MakeArrayFieldMappingTestCase<bool, bool>
-            (appValue: new bool[] {true, false}, bigQueryValue: new bool[] {true, false}, fetchOnly: false,
-                shouldSkip: false);
-            yield return MakeArrayFieldMappingTestCase<bool, string>
-            (appValue: new bool[] {true, false}, bigQueryValue: new string[] {"garbage"}, fetchOnly: true,
-                shouldSkip: true);
-        }
-
-        [Test, TestCaseSource(nameof(AddArrayFieldMappingTestCases))]
-        public void ArrayFieldMappedValueShouldBeCorrect(Type type, object value, object expectedBigQueryValue,
-            Value.MapResult expectedValueAgain, bool fetchOnly)
-        {
-            var fieldToBigQuery = Value.MaybeRepeatedFieldToBigQueryFunction(type.MakeArrayType());
-            var fieldFromBigQuery = Value.MaybeRepeatedFieldFromBigQueryFunction(type.MakeArrayType());
-
-            object bigQueryValue;
-            if (!fetchOnly)
-            {
-                bigQueryValue = fieldToBigQuery(value);
-                bigQueryValue
-                    .Should().BeEquivalentTo(expectedBigQueryValue);
-            }
-            else
-            {
-                bigQueryValue = expectedBigQueryValue;
-            }
-
-            if (expectedValueAgain.Skip)
-            {
-                fieldFromBigQuery(bigQueryValue).Skip.Should().BeTrue("Should skip");
-            }
-            else
-            {
-                fieldFromBigQuery(bigQueryValue).Value.Should().BeEquivalentTo(expectedValueAgain.Value);
-            }
-        }
-
-        #endregion
-
-        #endregion
+        public T Prop { get; set; }
     }
+
+    [QuerierContract]
+    private class WithArray<T>
+    {
+        public T[] Prop { get; set; }
+    }
+
+    #region Simple Field
+
+    #region Simple Field Schema
+
+    private static TestCaseData MakeSchemaFieldTestCase<T>(string bigQueryType)
+    {
+        return new TestCaseData(bigQueryType, Contract<With<T>>.Create().Cache)
+        {
+            TestName = $"{typeof(T)} fields should be {bigQueryType} in schema"
+        };
+    }
+
+    private static IEnumerable<TestCaseData> AddSchemaFieldTestCases()
+    {
+        yield return MakeSchemaFieldTestCase<string>("STRING");
+        yield return MakeSchemaFieldTestCase<long>("INTEGER");
+        yield return MakeSchemaFieldTestCase<long?>("INTEGER");
+        yield return MakeSchemaFieldTestCase<int>("INTEGER");
+        yield return MakeSchemaFieldTestCase<int?>("INTEGER");
+        yield return MakeSchemaFieldTestCase<double>("FLOAT");
+        yield return MakeSchemaFieldTestCase<double?>("FLOAT");
+        yield return MakeSchemaFieldTestCase<DateTime>("TIMESTAMP");
+        yield return MakeSchemaFieldTestCase<DateTime?>("TIMESTAMP");
+        yield return MakeSchemaFieldTestCase<bool>("BOOLEAN");
+        yield return MakeSchemaFieldTestCase<bool?>("BOOLEAN");
+    }
+
+    [Test, TestCaseSource(nameof(AddSchemaFieldTestCases))]
+    public void SchemaFieldTypeShouldBeCorrect(string bigQueryType, ContractCache contract)
+    {
+        contract.Schema.Fields.Should().HaveCount(1);
+        contract.Schema.Fields[0].Name.Should().Be("Prop");
+        contract.Schema.Fields[0].Mode.Should().Be("NULLABLE");
+        contract.Schema.Fields[0].Type.Should().Be(bigQueryType);
+    }
+
+    #endregion
+
+    #region Simple Field Mapping
+
+    private static TestCaseData MakeFieldMappingTestCase<TApp, TBigQuery>(TApp appValue, TBigQuery bigQueryValue,
+        bool fetchOnly, bool shouldSkip)
+    {
+        var type = typeof(TApp);
+        var caseMessage = fetchOnly ? "work for select" : "work for insert and select";
+        return new TestCaseData(type, appValue, bigQueryValue,
+            new Value.MapResult {Value = appValue, Skip = shouldSkip}, fetchOnly)
+        {
+            TestName = $"{typeof(TApp)} field mapping should {caseMessage}"
+        };
+    }
+
+    private static IEnumerable<TestCaseData> AddFieldMappingTestCases()
+    {
+        yield return MakeFieldMappingTestCase<string, string>
+            (appValue: "Hello", bigQueryValue: "Hello", fetchOnly: false, shouldSkip: false);
+        yield return MakeFieldMappingTestCase<string, int>
+            (appValue: "Hello", bigQueryValue: 123, fetchOnly: true, shouldSkip: true);
+
+        yield return MakeFieldMappingTestCase<long, long>
+            (appValue: 123, bigQueryValue: 123, fetchOnly: false, shouldSkip: false);
+        yield return MakeFieldMappingTestCase<long, string>
+            (appValue: 123, bigQueryValue: "garbage", fetchOnly: true, shouldSkip: true);
+        yield return MakeFieldMappingTestCase<long?, long?>
+            (appValue: 123, bigQueryValue: 123, fetchOnly: false, shouldSkip: false);
+        yield return MakeFieldMappingTestCase<long?, string>
+            (appValue: 123, bigQueryValue: "garbage", fetchOnly: true, shouldSkip: true);
+        yield return MakeFieldMappingTestCase<long?, long>
+            (appValue: 123, bigQueryValue: 123, fetchOnly: false, shouldSkip: false);
+        yield return MakeFieldMappingTestCase<long, long?>
+            (appValue: 123, bigQueryValue: 123, fetchOnly: false, shouldSkip: false);
+
+
+        yield return MakeFieldMappingTestCase<int, string>
+            (appValue: 123, bigQueryValue: "garbage", fetchOnly: true, shouldSkip: true);
+        yield return MakeFieldMappingTestCase<int?, string>
+            (appValue: 123, bigQueryValue: "garbage", fetchOnly: true, shouldSkip: true);
+        yield return MakeFieldMappingTestCase<int, long>
+            (appValue: 123, bigQueryValue: 123, fetchOnly: true, shouldSkip: false);
+        yield return MakeFieldMappingTestCase<int, long>
+            (appValue: 123, bigQueryValue: long.MaxValue, fetchOnly: true, shouldSkip: true);
+        yield return MakeFieldMappingTestCase<int?, long>
+            (appValue: 123, bigQueryValue: 123, fetchOnly: false, shouldSkip: false);
+        yield return MakeFieldMappingTestCase<int?, long?>
+            (appValue: 123, bigQueryValue: 123, fetchOnly: false, shouldSkip: false);
+        yield return MakeFieldMappingTestCase<int, long?>
+            (appValue: 123, bigQueryValue: 123, fetchOnly: false, shouldSkip: false);
+
+        yield return MakeFieldMappingTestCase<double, double>
+            (appValue: 123, bigQueryValue: 123, fetchOnly: false, shouldSkip: false);
+        yield return MakeFieldMappingTestCase<double, string>
+            (appValue: 123, bigQueryValue: "garbage", fetchOnly: true, shouldSkip: true);
+
+        yield return MakeFieldMappingTestCase<DateTime, DateTime>
+        (appValue: DateTime.Parse("2018-03-04 18:23:45"),
+            bigQueryValue: DateTime.Parse("2018-03-04 18:23:45"), fetchOnly: false, shouldSkip: false);
+        yield return MakeFieldMappingTestCase<DateTime, string>
+        (appValue: DateTime.Parse("2018-03-04 18:23:45"),
+            bigQueryValue: "garbage", fetchOnly: true, shouldSkip: true);
+
+        yield return MakeFieldMappingTestCase<bool, bool>
+            (appValue: true, bigQueryValue: true, fetchOnly: false, shouldSkip: false);
+        yield return MakeFieldMappingTestCase<bool, string>
+            (appValue: true, bigQueryValue: "garbage", fetchOnly: true, shouldSkip: true);
+    }
+
+    [Test, TestCaseSource(nameof(AddFieldMappingTestCases))]
+    public void FieldMappedValueShouldBeCorrect(Type type, object value, object expectedBigQueryValue,
+        Value.MapResult expectedValueAgain, bool fetchOnly)
+    {
+        var fieldToBigQuery = Value.MaybeFieldToBigQueryFunction(type);
+        var fieldFromBigQuery = Value.MaybeFieldFromBigQueryFunction(type);
+
+        object bigQueryValue;
+        if (!fetchOnly)
+        {
+            bigQueryValue = fieldToBigQuery(value);
+            bigQueryValue
+                .Should().BeEquivalentTo(expectedBigQueryValue,
+                    $"{type} value {value} should be {expectedBigQueryValue} when converted to big query value");
+        }
+        else
+        {
+            bigQueryValue = expectedBigQueryValue;
+        }
+
+        var valueAgain = fieldFromBigQuery(bigQueryValue);
+        if (expectedValueAgain.Skip)
+        {
+            valueAgain.Skip.Should()
+                .BeTrue($"Should skip setting {type} value {bigQueryValue} when converting from big query");
+        }
+        else
+        {
+            valueAgain.Value.Should().BeEquivalentTo(expectedValueAgain.Value,
+                $"Should set {type} value {bigQueryValue} to {expectedValueAgain.Value} when converting from big query");
+        }
+    }
+
+    #endregion
+
+    #endregion
+
+    #region Simple field with Array values
+
+    #region Simple field with Array values schema
+
+    private static TestCaseData MakeSchemaArrayFieldTestCase<T>(string bigQueryType)
+    {
+        return new TestCaseData(bigQueryType, Contract<WithArray<T>>.Create().Cache)
+        {
+            TestName = $"{typeof(T)} array fields should be REPEATED in schema and have {bigQueryType} type"
+        };
+    }
+
+    private static IEnumerable<TestCaseData> AddSchemaArrayFieldTestCases()
+    {
+        yield return MakeSchemaArrayFieldTestCase<string>("STRING");
+        yield return MakeSchemaArrayFieldTestCase<long>("INTEGER");
+        yield return MakeSchemaArrayFieldTestCase<long?>("INTEGER");
+        yield return MakeSchemaArrayFieldTestCase<int>("INTEGER");
+        yield return MakeSchemaArrayFieldTestCase<int?>("INTEGER");
+        yield return MakeSchemaArrayFieldTestCase<double>("FLOAT");
+        yield return MakeSchemaArrayFieldTestCase<double?>("FLOAT");
+        yield return MakeSchemaArrayFieldTestCase<DateTime>("TIMESTAMP");
+        yield return MakeSchemaArrayFieldTestCase<DateTime?>("TIMESTAMP");
+        yield return MakeSchemaArrayFieldTestCase<bool>("BOOLEAN");
+        yield return MakeSchemaArrayFieldTestCase<bool?>("BOOLEAN");
+    }
+
+    [Test, TestCaseSource(nameof(AddSchemaArrayFieldTestCases))]
+    public void SchemaArrayFieldTypeShouldBeCorrect(string bigQueryType, ContractCache contract)
+    {
+        contract.Schema.Fields.Should().HaveCount(1);
+        contract.Schema.Fields[0].Name.Should().Be("Prop");
+        contract.Schema.Fields[0].Mode.Should().Be("REPEATED");
+        contract.Schema.Fields[0].Type.Should().Be(bigQueryType);
+    }
+
+    #endregion
+
+    #region Simple Field Mapping
+
+    private static TestCaseData MakeArrayFieldMappingTestCase<TApp, TBigQuery>(TApp[] appValue,
+        TBigQuery[] bigQueryValue, bool fetchOnly, bool shouldSkip)
+    {
+        var type = typeof(TApp);
+        return new TestCaseData(type, appValue, bigQueryValue,
+            new Value.MapResult {Value = appValue, Skip = shouldSkip}, fetchOnly)
+        {
+            TestName = $"{type} array field mapping should work for insert and select"
+        };
+    }
+
+    private static IEnumerable<TestCaseData> AddArrayFieldMappingTestCases()
+    {
+        yield return MakeArrayFieldMappingTestCase<string, string>
+            (appValue: new[] {"Hello"}, bigQueryValue: new[] {"Hello"}, fetchOnly: false, shouldSkip: false);
+        yield return MakeArrayFieldMappingTestCase<string, long>
+            (appValue: new string[] { }, bigQueryValue: new long[] {123}, fetchOnly: true, shouldSkip: true);
+
+        yield return MakeArrayFieldMappingTestCase<long, long>
+        (appValue: new long[] {42, 123}, bigQueryValue: new long[] {42, 123}, fetchOnly: false,
+            shouldSkip: false);
+        yield return MakeArrayFieldMappingTestCase<long, bool>
+            (appValue: new long[] {42, 123}, bigQueryValue: new bool[] {true}, fetchOnly: true, shouldSkip: true);
+        yield return MakeArrayFieldMappingTestCase<long?, long?>
+        (appValue: new long?[] {42, null, 123}, bigQueryValue: new long?[] {42, null, 123}, fetchOnly: false,
+            shouldSkip: false);
+        yield return MakeArrayFieldMappingTestCase<long?, bool?>
+            (appValue: new long?[] {42, 123}, bigQueryValue: new bool?[] {true}, fetchOnly: true, shouldSkip: true);
+        yield return MakeArrayFieldMappingTestCase<long, long?>
+        (appValue: new long[] {42, 123}, bigQueryValue: new long?[] {42, 123}, fetchOnly: false,
+            shouldSkip: false);
+        yield return MakeArrayFieldMappingTestCase<long?, long>
+        (appValue: new long?[] {42, 123}, bigQueryValue: new long[] {42, 123}, fetchOnly: false,
+            shouldSkip: false);
+
+        yield return MakeArrayFieldMappingTestCase<int, long>
+        (appValue: new int[] { 42, 123 }, bigQueryValue: new long[] { 42, 123 }, fetchOnly: false,
+            shouldSkip: false);
+        yield return MakeArrayFieldMappingTestCase<int, bool>
+            (appValue: new int[] { 42, 123 }, bigQueryValue: new bool[] { true }, fetchOnly: true, shouldSkip: true);
+        yield return MakeArrayFieldMappingTestCase<int?, long?>
+        (appValue: new int?[] { 42, null, 123 }, bigQueryValue: new long?[] { 42, null, 123 }, fetchOnly: false,
+            shouldSkip: false);
+        yield return MakeArrayFieldMappingTestCase<int?, bool?>
+            (appValue: new int?[] { 42, 123 }, bigQueryValue: new bool?[] { true }, fetchOnly: true, shouldSkip: true);
+        yield return MakeArrayFieldMappingTestCase<int, long?>
+        (appValue: new int[] { 42, 123 }, bigQueryValue: new long?[] { 42, 123 }, fetchOnly: false,
+            shouldSkip: false);
+        yield return MakeArrayFieldMappingTestCase<int?, long>
+        (appValue: new int?[] { 42, 123 }, bigQueryValue: new long[] { 42, 123 }, fetchOnly: false,
+            shouldSkip: false);
+        yield return MakeArrayFieldMappingTestCase<int?, long>
+        (appValue: new int?[] { 42, 123 }, bigQueryValue: new long[] { 42, long.MaxValue }, fetchOnly: true,
+            shouldSkip: true);
+
+
+
+        yield return MakeArrayFieldMappingTestCase<double, double>
+        (appValue: new double[] {42, 123}, bigQueryValue: new double[] {42, 123}, fetchOnly: false,
+            shouldSkip: false);
+        yield return MakeArrayFieldMappingTestCase<double, bool>
+            (appValue: new double[] {42, 123}, bigQueryValue: new bool[] {true}, fetchOnly: true, shouldSkip: true);
+
+        yield return MakeArrayFieldMappingTestCase<DateTime, DateTime>
+        (appValue: new DateTime[]
+        {
+            DateTime.Parse("2019-11-10 11:23:11"),
+            DateTime.Parse("2019-11-10 11:23:12")
+        }, bigQueryValue: new DateTime[]
+        {
+            DateTime.Parse("2019-11-10 11:23:11"),
+            DateTime.Parse("2019-11-10 11:23:12")
+        }, fetchOnly: false, shouldSkip: false);
+        yield return MakeArrayFieldMappingTestCase<DateTime, bool>
+        (appValue: new DateTime[]
+        {
+            DateTime.Parse("2019-11-10 11:23:11"),
+            DateTime.Parse("2019-11-10 11:23:12")
+        }, bigQueryValue: new bool[] {true}, fetchOnly: true, shouldSkip: true);
+
+        yield return MakeArrayFieldMappingTestCase<bool, bool>
+        (appValue: new bool[] {true, false}, bigQueryValue: new bool[] {true, false}, fetchOnly: false,
+            shouldSkip: false);
+        yield return MakeArrayFieldMappingTestCase<bool, string>
+        (appValue: new bool[] {true, false}, bigQueryValue: new string[] {"garbage"}, fetchOnly: true,
+            shouldSkip: true);
+    }
+
+    [Test, TestCaseSource(nameof(AddArrayFieldMappingTestCases))]
+    public void ArrayFieldMappedValueShouldBeCorrect(Type type, object value, object expectedBigQueryValue,
+        Value.MapResult expectedValueAgain, bool fetchOnly)
+    {
+        var fieldToBigQuery = Value.MaybeRepeatedFieldToBigQueryFunction(type.MakeArrayType());
+        var fieldFromBigQuery = Value.MaybeRepeatedFieldFromBigQueryFunction(type.MakeArrayType());
+
+        object bigQueryValue;
+        if (!fetchOnly)
+        {
+            bigQueryValue = fieldToBigQuery(value);
+            bigQueryValue
+                .Should().BeEquivalentTo(expectedBigQueryValue);
+        }
+        else
+        {
+            bigQueryValue = expectedBigQueryValue;
+        }
+
+        if (expectedValueAgain.Skip)
+        {
+            fieldFromBigQuery(bigQueryValue).Skip.Should().BeTrue("Should skip");
+        }
+        else
+        {
+            fieldFromBigQuery(bigQueryValue).Value.Should().BeEquivalentTo(expectedValueAgain.Value);
+        }
+    }
+
+    #endregion
+
+    #endregion
 }

--- a/src/Trafi.BigQuerier.Tests/Trafi.BigQuerier.Tests.csproj
+++ b/src/Trafi.BigQuerier.Tests/Trafi.BigQuerier.Tests.csproj
@@ -1,15 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="NUnitLite" Version="4.2.2" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.40" />
   </ItemGroup>

--- a/src/Trafi.BigQuerier/AsyncSemaphore.cs
+++ b/src/Trafi.BigQuerier/AsyncSemaphore.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Trafi.BigQuerier;
+
+public class AsyncSemaphore
+{
+    private readonly SemaphoreSlim _inner;
+
+    /// <summary>
+    /// This initializes a <see cref="System.Threading.SemaphoreSlim"/> with initialCount and maxCount set to a value of <paramref name="allowedEntrances"/>
+    /// </summary>
+    /// <param name="allowedEntrances">A value used to initialize a <see cref="System.Threading.SemaphoreSlim"/> setting initialCount and maxCount</param>
+    public AsyncSemaphore(int allowedEntrances)
+    {
+        _inner = new SemaphoreSlim(allowedEntrances, allowedEntrances);
+    }
+
+    public async Task<Entry> Enter()
+    {
+        await _inner.WaitAsync();
+        return new Entry(_inner);
+    }
+
+    public async Task<Entry> Enter(CancellationToken ct)
+    {
+        await _inner.WaitAsync(ct);
+        return new Entry(_inner);
+    }
+
+    public async Task<Entry> Enter(TimeSpan timeout)
+    {
+        await _inner.WaitAsync(timeout);
+        return new Entry(_inner);
+    }
+
+    public class Entry : IDisposable
+    {
+        private readonly SemaphoreSlim _semaphore;
+
+        public Entry(SemaphoreSlim semaphore)
+        {
+            _semaphore = semaphore;
+        }
+
+        public void Dispose()
+        {
+            _semaphore.Release();
+        }
+    }
+}

--- a/src/Trafi.BigQuerier/BigQuerierException.cs
+++ b/src/Trafi.BigQuerier/BigQuerierException.cs
@@ -8,36 +8,35 @@
 using System;
 using Google.Apis.Bigquery.v2.Data;
 
-namespace Trafi.BigQuerier
+namespace Trafi.BigQuerier;
+
+public class BigQuerierException : Exception
 {
-    public class BigQuerierException : Exception
+    public JobStatus? JobStatus { get; }
+
+    public BigQuerierException(string message, JobStatus? jobStatus = null) : base(
+        CombineMessageWithJobErrorMessage(message, jobStatus))
     {
-        public JobStatus? JobStatus { get; }
+        JobStatus = jobStatus;
+    }
 
-        public BigQuerierException(string message, JobStatus? jobStatus = null) : base(
-            CombineMessageWithJobErrorMessage(message, jobStatus))
-        {
-            JobStatus = jobStatus;
-        }
+    public BigQuerierException(string message, Exception innerException, JobStatus? jobStatus = null) : base(
+        CombineMessageWithJobErrorMessage(message, jobStatus), innerException)
+    {
+        JobStatus = jobStatus;
+    }
 
-        public BigQuerierException(string message, Exception innerException, JobStatus? jobStatus = null) : base(
-            CombineMessageWithJobErrorMessage(message, jobStatus), innerException)
-        {
-            JobStatus = jobStatus;
-        }
+    private static string CombineMessageWithJobErrorMessage(string message, JobStatus? jobStatus)
+    {
+        if (jobStatus?.ErrorResult == null)
+            return message;
 
-        private static string CombineMessageWithJobErrorMessage(string message, JobStatus? jobStatus)
-        {
-            if (jobStatus?.ErrorResult == null)
-                return message;
+        var reasonText = jobStatus.ErrorResult.Reason != null ? $", {jobStatus.ErrorResult.Reason}" : "";
+        var jobError = (jobStatus.ErrorResult.Location != null
+                           ? $"Error in {jobStatus.ErrorResult.Location}{reasonText}: "
+                           : "")
+                       + jobStatus.ErrorResult.Message;
 
-            var reasonText = jobStatus.ErrorResult.Reason != null ? $", {jobStatus.ErrorResult.Reason}" : "";
-            var jobError = (jobStatus.ErrorResult.Location != null
-                               ? $"Error in {jobStatus.ErrorResult.Location}{reasonText}: "
-                               : "")
-                           + jobStatus.ErrorResult.Message;
-
-            return $"{message}. {jobError}";
-        }
+        return $"{message}. {jobError}";
     }
 }

--- a/src/Trafi.BigQuerier/BigQueryTableClient.cs
+++ b/src/Trafi.BigQuerier/BigQueryTableClient.cs
@@ -10,34 +10,33 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Trafi.BigQuerier
+namespace Trafi.BigQuerier;
+
+public class BigQueryTableClient : IBigQueryTableClient
 {
-    public class BigQueryTableClient : IBigQueryTableClient
+    private readonly BigQueryTable _table;
+
+    public BigQueryTableClient(BigQueryTable table)
     {
-        private readonly BigQueryTable _table;
+        _table = table;
+    }
 
-        public BigQueryTableClient(BigQueryTable table)
+    public async Task InsertRows(BigQueryInsertRow[] rows, CancellationToken ct)
+    {
+        try
         {
-            _table = table;
+            await _table.InsertRowsAsync(
+                rows,
+                new InsertOptions
+                {
+                    AllowUnknownFields = true,
+                },
+                cancellationToken: ct
+            );
         }
-
-        public async Task InsertRows(BigQueryInsertRow[] rows, CancellationToken ct)
+        catch (Exception ex)
         {
-            try
-            {
-                await _table.InsertRowsAsync(
-                    rows, 
-                    new InsertOptions
-                    {
-                        AllowUnknownFields = true,
-                    }, 
-                    cancellationToken: ct
-                );
-            }
-            catch (Exception ex)
-            {
-                throw new BigQuerierException($"Failed to insert row to {_table.FullyQualifiedId}", ex);
-            }
+            throw new BigQuerierException($"Failed to insert row to {_table.FullyQualifiedId}", ex);
         }
     }
 }

--- a/src/Trafi.BigQuerier/Contract.cs
+++ b/src/Trafi.BigQuerier/Contract.cs
@@ -9,44 +9,43 @@ using Google.Apis.Bigquery.v2.Data;
 using Google.Cloud.BigQuery.V2;
 using Trafi.BigQuerier.Mapper;
 
-namespace Trafi.BigQuerier
+namespace Trafi.BigQuerier;
+
+public class Contract<T>
 {
-    public class Contract<T>
+    private Contract(ContractCache cache)
     {
-        private Contract(ContractCache cache)
-        {
-            Cache = cache;
-        }
+        Cache = cache;
+    }
 
-        public static Contract<T> Create()
-        {
-            var type = typeof(T);
+    public static Contract<T> Create()
+    {
+        var type = typeof(T);
 
-            return new Contract<T>(
-                new ContractCache(
-                    Record.GetSchema(type),
-                    Record.GetValueToBigQueryFunction(type),
-                    Record.GetValueFromBigQueryFunction(type)
-                )
-            );
-        }
+        return new Contract<T>(
+            new ContractCache(
+                Record.GetSchema(type),
+                Record.GetValueToBigQueryFunction(type),
+                Record.GetValueFromBigQueryFunction(type)
+            )
+        );
+    }
 
-        public ContractCache Cache { get; }
+    public ContractCache Cache { get; }
 
-        public TableSchema Schema => Cache.Schema;
+    public TableSchema Schema => Cache.Schema;
 
-        #nullable disable
-        
-        public BigQueryInsertRow ToRow(T value)
-        {
-            return (BigQueryInsertRow) Cache.ValueToRow(value);
-        }
-        
-        #nullable restore
+#nullable disable
 
-        public T FromRow(BigQueryRow resultRow)
-        {
-            return (T) Cache.ValueFromRow(resultRow);
-        }
+    public BigQueryInsertRow ToRow(T value)
+    {
+        return (BigQueryInsertRow) Cache.ValueToRow(value);
+    }
+
+#nullable restore
+
+    public T FromRow(BigQueryRow resultRow)
+    {
+        return (T) Cache.ValueFromRow(resultRow);
     }
 }

--- a/src/Trafi.BigQuerier/ContractCache.cs
+++ b/src/Trafi.BigQuerier/ContractCache.cs
@@ -11,19 +11,18 @@ using System;
 
 #nullable disable
 
-namespace Trafi.BigQuerier
-{
-    public class ContractCache
-    {
-        public TableSchema Schema;
-        public Func<object, object> ValueToRow;
-        public Func<BigQueryRow, object> ValueFromRow;
+namespace Trafi.BigQuerier;
 
-        public ContractCache(TableSchema schema, Func<object, object> valueToRow, Func<BigQueryRow, object> valueFromRow)
-        {
-            Schema = schema;
-            ValueToRow = valueToRow;
-            ValueFromRow = valueFromRow;
-        }
+public class ContractCache
+{
+    public TableSchema Schema;
+    public Func<object, object> ValueToRow;
+    public Func<BigQueryRow, object> ValueFromRow;
+
+    public ContractCache(TableSchema schema, Func<object, object> valueToRow, Func<BigQueryRow, object> valueFromRow)
+    {
+        Schema = schema;
+        ValueToRow = valueToRow;
+        ValueFromRow = valueFromRow;
     }
 }

--- a/src/Trafi.BigQuerier/Dispatcher/DispatcherService.cs
+++ b/src/Trafi.BigQuerier/Dispatcher/DispatcherService.cs
@@ -30,33 +30,33 @@ public class DispatcherService : IDisposable
     private readonly IBigQueryClient _client;
     private readonly TableSchema _schema;
     private readonly int _batchSize;
+    private readonly int _maxQueueLength;
+    private readonly AsyncSemaphore _activeDispatchesSemaphore;
+    private readonly ManualResetEventSlim _pauseManualResetEvent = new(false);
+    private readonly ConcurrentDictionary<AsyncSemaphore.Entry, Task> _dispatchToBigQueryTasks = [];
 
     private readonly Dataset? _createDatasetOptions;
 
-    private readonly TimeSpan _timeToFinish = TimeSpan.FromSeconds(5);
-    private readonly TimeSpan _storageRestDuration = TimeSpan.FromMilliseconds(500);
     private readonly TimeSpan _sendBatchInterval = TimeSpan.FromSeconds(2);
-    private const int MaxQueueLength = 1_000_000;
+    private DateTimeOffset _lastDispatchCheck = DateTimeOffset.MinValue;
 
-    private DateTime _lastBatchSent = DateTime.MinValue;
-
-    private readonly BlockingCollection<QueueItem> _queue = new BlockingCollection<QueueItem>(MaxQueueLength);
-    private readonly ConcurrentQueue<QueueItem> _storageQueue = new ConcurrentQueue<QueueItem>();
-    private readonly CancellationTokenSource _tokenSource;
-    private readonly Task _consumeTask;
-    private readonly Task _storageTask;
+    private readonly ConcurrentQueue<QueueItem> _outboundQueue = new();
+    private readonly Task _internalDispatchTask;
+    private bool _disposing = false;
 
     private readonly IDispatchLogger? _logger;
 
-    public int? LastEntriesBatchSize { get; set; }
-    public TimeSpan? LastBatchSendTime { get; set; }
-    public int QueueSize => _queue.Count;
+    private TimeProvider _timeProvider = TimeProvider.System;
+
+    public int QueueSize => _outboundQueue.Count;
 
     public DispatcherService(IBigQueryClient client,
         TableSchema schema,
         string datasetId,
         Func<DateTime, string> tableNameFun,
         int batchSize,
+        int concurrentDispatches = 1,
+        int maxQueueLength = 1_000_000,
         Dataset? createDatasetOptions = null,
         IDispatchLogger? logger = null)
     {
@@ -65,13 +65,12 @@ public class DispatcherService : IDisposable
         _datasetId = datasetId;
         _tableNameFun = tableNameFun;
         _batchSize = batchSize;
+        _maxQueueLength = maxQueueLength;
+        _activeDispatchesSemaphore = new AsyncSemaphore(concurrentDispatches);
         _createDatasetOptions = createDatasetOptions;
         _logger = logger;
 
-        _tokenSource = new CancellationTokenSource();
-        _consumeTask = Task.Factory.StartNew(() => RunConsume(_tokenSource.Token), TaskCreationOptions.LongRunning);
-        _storageTask = Task.Factory.StartNew(() => RunStorage(_tokenSource.Token),
-            TaskCreationOptions.LongRunning);
+        _internalDispatchTask = Task.Run(RunInternalDispatch);
     }
 
     public DispatcherService(
@@ -80,24 +79,39 @@ public class DispatcherService : IDisposable
         string datasetId,
         Func<DateTime, string> tableNameFun,
         Dataset? createDatasetOptions = null,
-        IDispatchLogger? logger = null) : this(client, schema, datasetId, tableNameFun, 100, createDatasetOptions, logger)
+        IDispatchLogger? logger = null) :
+        this(client, schema, datasetId, tableNameFun,
+            batchSize: 100,
+            concurrentDispatches: 1,
+            maxQueueLength: 1_000_000,
+            createDatasetOptions,
+            logger)
     {
     }
 
+    /// <summary>
+    /// Enqueues a row to be dispatched to BigQuery.
+    /// </summary>
+    /// <param name="time">Time for determining table name, passed to tableNameFun</param>
+    /// <param name="row">Row to insert to BigQuery</param>
     public void Dispatch(DateTime time, BigQueryInsertRow row)
     {
-        Dispatch(time, row, CancellationToken.None);
-    }
+        var queueSize = _outboundQueue.Count;
+        if (queueSize >= _maxQueueLength)
+        {
+            _logger?.CannotAdd(row);
+            return;
+        }
 
-    public void Dispatch(DateTime time, BigQueryInsertRow row, CancellationToken ct)
-    {
         var queueItem = new QueueItem
         {
             Row = row,
             Time = time
         };
-        if (!_queue.TryAdd(queueItem, 0, ct))
-            _logger?.CannotAdd(queueItem.Row);
+
+        _outboundQueue.Enqueue(queueItem);
+        if (queueSize + 1 == _batchSize)
+            _pauseManualResetEvent.Set();
     }
 
     public async Task<BigQueryDataset> GetOrCreateDatasetAsync(CancellationToken ct = default)
@@ -108,99 +122,141 @@ public class DispatcherService : IDisposable
             cancellationToken: ct);
     }
 
-    private void RunConsume(CancellationToken ct)
+    private async Task RunInternalDispatch()
     {
-        try
+        while (true)
         {
-            foreach (var item in _queue.GetConsumingEnumerable(ct))
+            var pause = _sendBatchInterval - (_timeProvider.GetUtcNow() - _lastDispatchCheck);
+            var queueSize = _outboundQueue.Count;
+            var shouldPauseForUnfilledBatch = pause > TimeSpan.Zero && queueSize < _batchSize;
+            if (shouldPauseForUnfilledBatch && !_disposing)
             {
-                _storageQueue.Enqueue(item);
+                // Since ManualResetEventSlim doesn't have TimeProvider enabled API, we use CancellationTokenSource
+                // to enable cancelling the wait from tests
+                var cts = new CancellationTokenSource(pause, _timeProvider);
+                try
+                {
+                    var signaled = _pauseManualResetEvent.Wait(pause, cts.Token);
+                    if (signaled)
+                        _pauseManualResetEvent.Reset();
+                }
+                catch (OperationCanceledException)
+                {
+                }
+
+                // Update queue size after pause
+                queueSize = _outboundQueue.Count;
             }
+
+            _lastDispatchCheck = _timeProvider.GetUtcNow();
+
+            if (queueSize == 0)
+            {
+                if (_disposing)
+                    break;
+
+                continue;
+            }
+
+            // Can enter up to the `concurrentDispatches` limit
+            var entry = await _activeDispatchesSemaphore.Enter(CancellationToken.None);
+
+            var batch = DequeueBatch(Math.Min(_batchSize, queueSize));
+            // We track active dispatches to wait for them to finish when dispatcher is disposed/stopped/cancelled
+            _dispatchToBigQueryTasks[entry] = Task.Run(async () =>
+            {
+                using (entry) // Release semaphore when done
+                {
+                    await DispatchToBigQuerySafe(batch);
+                    _dispatchToBigQueryTasks.Remove(entry, out _);
+                }
+            });
         }
-        catch (OperationCanceledException)
-        {
-        }
+
+        // Wait for all remaining tasks to finish when dispatcher is disposed/stopped/cancelled
+        await Task.WhenAll(_dispatchToBigQueryTasks.Values);
     }
 
-    private void RunStorage(CancellationToken ct)
+    private List<QueueItem> DequeueBatch(int count)
     {
-        while (!ct.IsCancellationRequested)
-        {
-            if (_storageQueue.Count >= _batchSize)
-            {
-                Save(_batchSize, ct: ct);
-            }
-            else if (DateTime.UtcNow.Subtract(_lastBatchSent) > _sendBatchInterval && !_storageQueue.IsEmpty)
-            {
-                Save(_storageQueue.Count, ct: ct);
-            }
-            ct.WaitHandle.WaitOne(_storageRestDuration);
-        }
-
-        while (!_storageQueue.IsEmpty)
-        {
-            var count = Math.Min(_storageQueue.Count, _batchSize);
-            Save(count, ct: ct);
-        }
-    }
-
-    private void Save(int count, CancellationToken ct = default)
-    {
-        var items = new List<QueueItem>();
+        var items = new List<QueueItem>(count);
         for (var i = 0; i < count; i++)
         {
-            if (_storageQueue.TryDequeue(out var item))
-                items.Add(item);
+            if (!_outboundQueue.TryDequeue(out var item))
+                break;
+
+            items.Add(item);
         }
-        Store(items, ct: ct);
-        _lastBatchSent = DateTime.UtcNow;
+
+        return items;
     }
 
-    private void Store(IReadOnlyCollection<QueueItem> items, CancellationToken ct = default)
+    private async Task DispatchToBigQuerySafe(IReadOnlyCollection<QueueItem> items)
+    {
+        var traceId = Guid.NewGuid().ToString();
+
+        try
+        {
+            await DispatchToBigQuery(items, traceId);
+        }
+        catch (Exception e)
+        {
+            _logger?.InsertError(e, items.Select(b => b.Row).ToArray(), traceId);
+        }
+    }
+
+    private async Task DispatchToBigQuery(IReadOnlyCollection<QueueItem> items, string traceId)
     {
         var sw = Stopwatch.StartNew();
-        var traceId = Guid.NewGuid().ToString();
         var stored = 0;
+
         foreach (var batch in items.GroupBy(item => _tableNameFun(item.Time)))
         {
             var tableName = batch.Key;
             var insertRows = batch.Select(b => b.Row).ToArray();
             try
             {
-                var client = _client.GetTableClient(_datasetId, tableName, _schema,
-                    createDatasetOptions: _createDatasetOptions,
-                    ct: ct).Result;
+                var client = await _client.GetTableClient(
+                    _datasetId, tableName, _schema,
+                    createDatasetOptions: _createDatasetOptions);
 
                 stored += insertRows.Length;
                 _logger?.InsertRows(insertRows.Length, traceId);
 
-                client.InsertRows(insertRows, CancellationToken.None).Wait(ct);
+                await client.InsertRows(insertRows, CancellationToken.None);
             }
             catch (Exception ex)
             {
                 _logger?.InsertError(ex, insertRows, traceId);
             }
         }
+
         sw.Stop();
-        LastBatchSendTime = sw.Elapsed;
-        LastEntriesBatchSize = items.Count;
         _logger?.Stored(
             stored: stored,
             timeTakenMs: (int)sw.Elapsed.TotalMilliseconds,
-            remainingInQueue: _storageQueue.Count,
+            remainingInQueue: _outboundQueue.Count,
             traceId: traceId);
     }
 
     public void Dispose()
     {
-        _queue.CompleteAdding();
-        _consumeTask.Wait(_timeToFinish);
-        _tokenSource.Cancel();
+        _disposing = true;
+        _pauseManualResetEvent.Set();
 
         _logger?.WaitForEnd();
-        _storageTask.Wait();
+        _internalDispatchTask.Wait();
 
-        if (!_storageQueue.IsEmpty)
-            _logger?.UnsentRows(_storageQueue.Select(q => q.Row).ToArray());
+        if (!_outboundQueue.IsEmpty)
+            _logger?.UnsentRows(_outboundQueue.Select(q => q.Row).ToArray());
+    }
+
+    internal static class TestAccessor
+    {
+        internal static void SetTimeProvider(DispatcherService dispatcherService, TimeProvider timeProvider)
+            => dispatcherService._timeProvider = timeProvider;
+
+        internal static ICollection<Task> GetDispatchToBigQueryTasks(DispatcherService dispatcherService)
+            => dispatcherService._dispatchToBigQueryTasks.Values;
     }
 }

--- a/src/Trafi.BigQuerier/Dispatcher/IDispatchLogger.cs
+++ b/src/Trafi.BigQuerier/Dispatcher/IDispatchLogger.cs
@@ -8,22 +8,21 @@
 using System;
 using Google.Cloud.BigQuery.V2;
 
-namespace Trafi.BigQuerier.Dispatcher
+namespace Trafi.BigQuerier.Dispatcher;
+
+public interface IDispatchLogger
 {
-    public interface IDispatchLogger
-    {
-        void WaitForEnd();
-        void InsertRows(int insertRowsCount, string traceId);
-        void InsertError(Exception ex, BigQueryInsertRow[] insertRows, string traceId);
-        void UnsentRows(BigQueryInsertRow[] insertRows);
-        void CannotAdd(BigQueryInsertRow row);
-        /// <summary>
-        /// Called after a batch is stored
-        /// </summary>
-        /// <param name="stored">Stored items count</param>
-        /// <param name="timeTakenMs">Time taken to Store the batch in milliseconds</param>
-        /// <param name="remainingInQueue">Items remaining in queue</param>
-        /// <param name="traceId">TraceId, unique per Storage attempt</param>
-        void Stored(int stored, int timeTakenMs, int remainingInQueue, string traceId);
-    }
+    void WaitForEnd();
+    void InsertRows(int insertRowsCount, string traceId);
+    void InsertError(Exception ex, BigQueryInsertRow[] insertRows, string traceId);
+    void UnsentRows(BigQueryInsertRow[] insertRows);
+    void CannotAdd(BigQueryInsertRow row);
+    /// <summary>
+    /// Called after a batch is stored
+    /// </summary>
+    /// <param name="stored">Stored items count</param>
+    /// <param name="timeTakenMs">Time taken to Store the batch in milliseconds</param>
+    /// <param name="remainingInQueue">Items remaining in queue</param>
+    /// <param name="traceId">TraceId, unique per Storage attempt</param>
+    void Stored(int stored, int timeTakenMs, int remainingInQueue, string traceId);
 }

--- a/src/Trafi.BigQuerier/IBigQueryClient.cs
+++ b/src/Trafi.BigQuerier/IBigQueryClient.cs
@@ -11,59 +11,58 @@ using Google.Cloud.BigQuery.V2;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Trafi.BigQuerier
+namespace Trafi.BigQuerier;
+
+public interface IBigQueryClient
 {
-    public interface IBigQueryClient
-    {
-        Google.Cloud.BigQuery.V2.BigQueryClient InnerClient { get; }
+    Google.Cloud.BigQuery.V2.BigQueryClient InnerClient { get; }
 
-        /// <summary>
-        /// Gets or creates table and returns client to work with it.
-        /// </summary>
-        /// <param name="datasetId">Dataset id</param>
-        /// <param name="tableId">Table id</param>
-        /// <param name="schema">Schema</param>
-        /// <param name="createDatasetOptions">BigQuery dataset creation options</param>
-        /// <param name="ct">Cancellation token</param>
-        /// <returns>Table client</returns>
-        Task<IBigQueryTableClient> GetTableClient(
-            string datasetId,
-            string tableId,
-            TableSchema schema,
-            Dataset? createDatasetOptions = null,
-            CancellationToken ct = default
-        );
+    /// <summary>
+    /// Gets or creates table and returns client to work with it.
+    /// </summary>
+    /// <param name="datasetId">Dataset id</param>
+    /// <param name="tableId">Table id</param>
+    /// <param name="schema">Schema</param>
+    /// <param name="createDatasetOptions">BigQuery dataset creation options</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Table client</returns>
+    Task<IBigQueryTableClient> GetTableClient(
+        string datasetId,
+        string tableId,
+        TableSchema schema,
+        Dataset? createDatasetOptions = null,
+        CancellationToken ct = default
+    );
 
-        /// <summary>
-        /// Execute a query.
-        /// </summary>
-        /// <param name="sql">SQL</param>
-        /// <param name="options">Query options</param>
-        /// <param name="ct">Cancellation token</param>
-        /// <returns>Rows</returns>
-        Task<IAsyncEnumerable<BigQueryRow>> Query(string sql, QueryOptions? options = null,
-            CancellationToken ct = default);
-        
-        /// <summary>
-        /// Execute a query with parameters.
-        /// </summary>
-        /// <param name="sql">SQL</param>
-        /// <param name="namedParameters">Query parameters</param>
-        /// <param name="options">Query options</param>
-        /// <param name="ct">Cancellation token</param>
-        /// <returns>Rows</returns>
-        Task<IAsyncEnumerable<BigQueryRow>> ParametricQuery(
-            string sql,
-            IList<BigQueryParameter> namedParameters,
-            QueryOptions options,
-            CancellationToken ct = default);
-        
-        /// <summary>
-        /// Delete a table.
-        /// </summary>
-        /// <param name="datasetId">Dataset id</param>
-        /// <param name="tableId">Table id</param>
-        /// <param name="ct">Cancellation token</param>
-        Task DeleteTable(string datasetId, string tableId, CancellationToken ct = default);
-    }
+    /// <summary>
+    /// Execute a query.
+    /// </summary>
+    /// <param name="sql">SQL</param>
+    /// <param name="options">Query options</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Rows</returns>
+    Task<IAsyncEnumerable<BigQueryRow>> Query(string sql, QueryOptions? options = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Execute a query with parameters.
+    /// </summary>
+    /// <param name="sql">SQL</param>
+    /// <param name="namedParameters">Query parameters</param>
+    /// <param name="options">Query options</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Rows</returns>
+    Task<IAsyncEnumerable<BigQueryRow>> ParametricQuery(
+        string sql,
+        IList<BigQueryParameter> namedParameters,
+        QueryOptions options,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Delete a table.
+    /// </summary>
+    /// <param name="datasetId">Dataset id</param>
+    /// <param name="tableId">Table id</param>
+    /// <param name="ct">Cancellation token</param>
+    Task DeleteTable(string datasetId, string tableId, CancellationToken ct = default);
 }

--- a/src/Trafi.BigQuerier/IBigQueryTableClient.cs
+++ b/src/Trafi.BigQuerier/IBigQueryTableClient.cs
@@ -9,15 +9,14 @@ using Google.Cloud.BigQuery.V2;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Trafi.BigQuerier
+namespace Trafi.BigQuerier;
+
+public interface IBigQueryTableClient
 {
-    public interface IBigQueryTableClient
-    {
-        /// <summary>
-        /// Inserts rows.
-        /// </summary>
-        /// <param name="rows">Rows to insert</param>
-        /// <param name="ct">Cancellation token</param>
-        Task InsertRows(BigQueryInsertRow[] rows, CancellationToken ct);
-    }
+    /// <summary>
+    /// Inserts rows.
+    /// </summary>
+    /// <param name="rows">Rows to insert</param>
+    /// <param name="ct">Cancellation token</param>
+    Task InsertRows(BigQueryInsertRow[] rows, CancellationToken ct);
 }

--- a/src/Trafi.BigQuerier/Mapper/Property.cs
+++ b/src/Trafi.BigQuerier/Mapper/Property.cs
@@ -12,104 +12,103 @@ using System.Reflection;
 
 #nullable disable
 
-namespace Trafi.BigQuerier.Mapper
+namespace Trafi.BigQuerier.Mapper;
+
+public static class Property
 {
-    public static class Property
+    public static void AppendRecordFieldSchema(TableSchemaBuilder tableBuilder, string name, Type type)
     {
-        public static void AppendRecordFieldSchema(TableSchemaBuilder tableBuilder, string name, Type type)
+        var simpleFieldOptions = Value.MaybeSimpleFieldOptionsFromType(type);
+        if (simpleFieldOptions != null)
         {
-            var simpleFieldOptions = Value.MaybeSimpleFieldOptionsFromType(type);
-            if (simpleFieldOptions != null)
-            {
-                tableBuilder.Add(name, simpleFieldOptions.Type, simpleFieldOptions.Mode);
-                return;
-            }
-
-            if (type.IsArray)
-            {
-                var elementType = type.GetElementType();
-                var simpleArrayElementFieldOptions = Value.MaybeSimpleFieldOptionsFromType(elementType);
-                if (null != simpleArrayElementFieldOptions)
-                {
-                    tableBuilder.Add(name, simpleArrayElementFieldOptions.Type, BigQueryFieldMode.Repeated);
-                    return;
-                }
-
-                if (Record.IsContractType(elementType))
-                {
-                    tableBuilder.Add(name, Record.GetSchema(elementType), BigQueryFieldMode.Repeated);
-                    return;
-                }
-            }
-
-            if (Record.IsContractType(type))
-            {
-                tableBuilder.Add(name, Record.GetSchema(type), BigQueryFieldMode.Nullable);
-                return;
-            }
-
-            throw new NotImplementedException($"Type {type.FullName} is not a valid BigQuerier Contract field");
+            tableBuilder.Add(name, simpleFieldOptions.Type, simpleFieldOptions.Mode);
+            return;
         }
 
-        public static Action<object, BigQueryInsertRow> GetBigQueryRecordFieldAppendFunction(PropertyInfo p)
+        if (type.IsArray)
         {
-            var propertyName = p.Name;
-            var objectMapFunction = Value.MaybeFieldToBigQueryFunction(p.PropertyType);
-            if (null != objectMapFunction)
+            var elementType = type.GetElementType();
+            var simpleArrayElementFieldOptions = Value.MaybeSimpleFieldOptionsFromType(elementType);
+            if (null != simpleArrayElementFieldOptions)
             {
-                return (instance, row) =>
-                {
-                    row.Add(propertyName, objectMapFunction(p.GetValue(instance)));
-                };
+                tableBuilder.Add(name, simpleArrayElementFieldOptions.Type, BigQueryFieldMode.Repeated);
+                return;
             }
 
-            var repeatedObjectMapFunction = Value.MaybeRepeatedFieldToBigQueryFunction(p.PropertyType);
-            if (null != repeatedObjectMapFunction)
+            if (Record.IsContractType(elementType))
             {
-                return (instance, row) =>
-                {
-                    row.Add(propertyName, repeatedObjectMapFunction(p.GetValue(instance)));
-                };
+                tableBuilder.Add(name, Record.GetSchema(elementType), BigQueryFieldMode.Repeated);
+                return;
             }
+        }
 
-            var recordMapFunction = Record.GetValueToBigQueryFunction(p.PropertyType);
+        if (Record.IsContractType(type))
+        {
+            tableBuilder.Add(name, Record.GetSchema(type), BigQueryFieldMode.Nullable);
+            return;
+        }
+
+        throw new NotImplementedException($"Type {type.FullName} is not a valid BigQuerier Contract field");
+    }
+
+    public static Action<object, BigQueryInsertRow> GetBigQueryRecordFieldAppendFunction(PropertyInfo p)
+    {
+        var propertyName = p.Name;
+        var objectMapFunction = Value.MaybeFieldToBigQueryFunction(p.PropertyType);
+        if (null != objectMapFunction)
+        {
             return (instance, row) =>
             {
-                row.Add(propertyName, recordMapFunction(p.GetValue(instance)));
+                row.Add(propertyName, objectMapFunction(p.GetValue(instance)));
             };
         }
 
-        public static Action<object, object> GetPropertySetFromObjectFunction(PropertyInfo p)
+        var repeatedObjectMapFunction = Value.MaybeRepeatedFieldToBigQueryFunction(p.PropertyType);
+        if (null != repeatedObjectMapFunction)
         {
-            var objectMapFunction = Value.MaybeFieldFromBigQueryFunction(p.PropertyType);
-            if (null != objectMapFunction)
+            return (instance, row) =>
             {
-                return (fromObj, instanceObjext) =>
-                {
-                    var mapResult = objectMapFunction(fromObj);
-                    if (!mapResult.Skip) {
-                        p.SetValue(instanceObjext, mapResult.Value);
-                    }
-                };
-            }
-
-            var repeatedObjectMapFunction = Value.MaybeRepeatedFieldFromBigQueryFunction(p.PropertyType);
-            if (null != repeatedObjectMapFunction)
-            {
-                return (fromObj, instanceObjext) =>
-                {
-                    var result = repeatedObjectMapFunction(fromObj);
-                    if (!result.Skip) {
-                        p.SetValue(instanceObjext, result.Value);
-                    }
-                };
-            }
-
-            var elementMapFunction = Record.GetValueFromBigQueryDictionaryFunction(p.PropertyType);
-            return (fromObj, instanceObject) =>
-            {
-                p.SetValue(instanceObject, elementMapFunction((Dictionary<string, object>)fromObj));
+                row.Add(propertyName, repeatedObjectMapFunction(p.GetValue(instance)));
             };
         }
+
+        var recordMapFunction = Record.GetValueToBigQueryFunction(p.PropertyType);
+        return (instance, row) =>
+        {
+            row.Add(propertyName, recordMapFunction(p.GetValue(instance)));
+        };
+    }
+
+    public static Action<object, object> GetPropertySetFromObjectFunction(PropertyInfo p)
+    {
+        var objectMapFunction = Value.MaybeFieldFromBigQueryFunction(p.PropertyType);
+        if (null != objectMapFunction)
+        {
+            return (fromObj, instanceObjext) =>
+            {
+                var mapResult = objectMapFunction(fromObj);
+                if (!mapResult.Skip) {
+                    p.SetValue(instanceObjext, mapResult.Value);
+                }
+            };
+        }
+
+        var repeatedObjectMapFunction = Value.MaybeRepeatedFieldFromBigQueryFunction(p.PropertyType);
+        if (null != repeatedObjectMapFunction)
+        {
+            return (fromObj, instanceObjext) =>
+            {
+                var result = repeatedObjectMapFunction(fromObj);
+                if (!result.Skip) {
+                    p.SetValue(instanceObjext, result.Value);
+                }
+            };
+        }
+
+        var elementMapFunction = Record.GetValueFromBigQueryDictionaryFunction(p.PropertyType);
+        return (fromObj, instanceObject) =>
+        {
+            p.SetValue(instanceObject, elementMapFunction((Dictionary<string, object>)fromObj));
+        };
     }
 }

--- a/src/Trafi.BigQuerier/Mapper/Record.cs
+++ b/src/Trafi.BigQuerier/Mapper/Record.cs
@@ -14,127 +14,126 @@ using System.Reflection;
 
 #nullable disable
 
-namespace Trafi.BigQuerier.Mapper
+namespace Trafi.BigQuerier.Mapper;
+
+public static class Record
 {
-    public static class Record
+    public static TableSchema GetSchema(Type type)
     {
-        public static TableSchema GetSchema(Type type)
+        if (!IsContractType(type))
         {
-            if (!IsContractType(type))
-            {
-                throw new NotImplementedException($"Type {type.FullName} is not supported by BigQuerier Contract (maybe QuerierContract attribute is missing?)");
-            }
-
-            var builder = new TableSchemaBuilder();
-            foreach (var property in FilterValidTypeProperties(type))
-            {
-                Property.AppendRecordFieldSchema(builder, property.Name, property.PropertyType);
-            }
-
-            return builder.Build();
+            throw new NotImplementedException($"Type {type.FullName} is not supported by BigQuerier Contract (maybe QuerierContract attribute is missing?)");
         }
 
-        public static Func<object, BigQueryInsertRow> GetValueToBigQueryFunction(Type type)
+        var builder = new TableSchemaBuilder();
+        foreach (var property in FilterValidTypeProperties(type))
         {
-            if (!IsContractType(type))
-            {
-                throw new NotImplementedException($"Type {type.FullName} is not supported by BigQuerier Contract (maybe QuerierContract attribute is missing?)");
-            }
-
-            var propertyMappers = FilterValidTypeProperties(type)
-                .Select(p => Property.GetBigQueryRecordFieldAppendFunction(p))
-                .ToArray();
-
-            return value =>
-            {
-                if (value == null)
-                {
-                    return null;
-                }
-
-                var row = new BigQueryInsertRow();
-                foreach (var mapper in propertyMappers)
-                {
-                    mapper(value, row);
-                }
-                return row;
-            };
+            Property.AppendRecordFieldSchema(builder, property.Name, property.PropertyType);
         }
 
-        public static Func<BigQueryRow, object> GetValueFromBigQueryFunction(Type type)
+        return builder.Build();
+    }
+
+    public static Func<object, BigQueryInsertRow> GetValueToBigQueryFunction(Type type)
+    {
+        if (!IsContractType(type))
         {
-            if (!IsContractType(type))
+            throw new NotImplementedException($"Type {type.FullName} is not supported by BigQuerier Contract (maybe QuerierContract attribute is missing?)");
+        }
+
+        var propertyMappers = FilterValidTypeProperties(type)
+            .Select(p => Property.GetBigQueryRecordFieldAppendFunction(p))
+            .ToArray();
+
+        return value =>
+        {
+            if (value == null)
             {
-                throw new NotImplementedException($"Type {type.FullName} is not supported by BigQuerier Contract (maybe QuerierContract attribute is missing?)");
+                return null;
             }
 
-            var propertyMappers = FilterValidTypeProperties(type)
-                .Select(p => new { Mapper = Property.GetPropertySetFromObjectFunction(p), Name = p.Name })
-                .ToArray();
-
-            var constructor = type.GetConstructor(new Type[] { });
-            
-            return row =>
+            var row = new BigQueryInsertRow();
+            foreach (var mapper in propertyMappers)
             {
-                var obj = constructor.Invoke(new object[] { });
-                foreach (var item in propertyMappers)
-                {
-                    object rowField;
-                    try
-                    {
-                        rowField = row[item.Name];
-                    }
-                    catch
-                    {
-                        continue;
-                    }
+                mapper(value, row);
+            }
+            return row;
+        };
+    }
 
+    public static Func<BigQueryRow, object> GetValueFromBigQueryFunction(Type type)
+    {
+        if (!IsContractType(type))
+        {
+            throw new NotImplementedException($"Type {type.FullName} is not supported by BigQuerier Contract (maybe QuerierContract attribute is missing?)");
+        }
+
+        var propertyMappers = FilterValidTypeProperties(type)
+            .Select(p => new { Mapper = Property.GetPropertySetFromObjectFunction(p), Name = p.Name })
+            .ToArray();
+
+        var constructor = type.GetConstructor(new Type[] { });
+
+        return row =>
+        {
+            var obj = constructor.Invoke(new object[] { });
+            foreach (var item in propertyMappers)
+            {
+                object rowField;
+                try
+                {
+                    rowField = row[item.Name];
+                }
+                catch
+                {
+                    continue;
+                }
+
+                item.Mapper(rowField, obj);
+            }
+            return obj;
+        };
+    }
+
+    public static Func<Dictionary<string, object>, object> GetValueFromBigQueryDictionaryFunction(Type type)
+    {
+        if (!IsContractType(type))
+        {
+            throw new NotImplementedException($"Type {type.FullName} is not supported by BigQuerier Contract (maybe QuerierContract attribute is missing?)");
+        }
+
+        var propertyMappers = FilterValidTypeProperties(type)
+            .Select(p => new { Mapper = Property.GetPropertySetFromObjectFunction(p), Name = p.Name })
+            .ToArray();
+
+        return row =>
+        {
+            if (row == null)
+            {
+                return null;
+            }
+
+            var obj = Activator.CreateInstance(type);
+            foreach (var item in propertyMappers)
+            {
+                object rowField;
+                if (row.TryGetValue(item.Name, out rowField))
+                {
                     item.Mapper(rowField, obj);
                 }
-                return obj;
-            };
-        }
-
-        public static Func<Dictionary<string, object>, object> GetValueFromBigQueryDictionaryFunction(Type type)
-        {
-            if (!IsContractType(type))
-            {
-                throw new NotImplementedException($"Type {type.FullName} is not supported by BigQuerier Contract (maybe QuerierContract attribute is missing?)");
             }
+            return obj;
+        };
+    }
 
-            var propertyMappers = FilterValidTypeProperties(type)
-                .Select(p => new { Mapper = Property.GetPropertySetFromObjectFunction(p), Name = p.Name })
-                .ToArray();
-            
-            return row =>
-            {
-                if (row == null)
-                {
-                    return null;
-                }
+    private static IEnumerable<PropertyInfo> FilterValidTypeProperties(Type type)
+    {
+        return type.GetProperties()
+            .Where(p => p.MemberType == MemberTypes.Property && p.CanRead && p.CanWrite);
+    }
 
-                var obj = Activator.CreateInstance(type);
-                foreach (var item in propertyMappers)
-                {
-                    object rowField;
-                    if (row.TryGetValue(item.Name, out rowField))
-                    {
-                        item.Mapper(rowField, obj);
-                    }
-                }
-                return obj;
-            };
-        }
-
-        private static IEnumerable<PropertyInfo> FilterValidTypeProperties(Type type)
-        {
-            return type.GetProperties()
-                    .Where(p => p.MemberType == MemberTypes.Property && p.CanRead && p.CanWrite);
-        }
-
-        public static bool IsContractType(Type type)
-        {
-            return type.GetTypeInfo().GetCustomAttribute<QuerierContract>() != null;
-        }
+    public static bool IsContractType(Type type)
+    {
+        return type.GetTypeInfo().GetCustomAttribute<QuerierContract>() != null;
     }
 }

--- a/src/Trafi.BigQuerier/Mapper/Record.cs
+++ b/src/Trafi.BigQuerier/Mapper/Record.cs
@@ -72,11 +72,11 @@ public static class Record
             .Select(p => new { Mapper = Property.GetPropertySetFromObjectFunction(p), Name = p.Name })
             .ToArray();
 
-        var constructor = type.GetConstructor(new Type[] { });
+        var constructor = type.GetConstructor([]);
 
         return row =>
         {
-            var obj = constructor.Invoke(new object[] { });
+            var obj = constructor.Invoke([]);
             foreach (var item in propertyMappers)
             {
                 object rowField;
@@ -116,8 +116,7 @@ public static class Record
             var obj = Activator.CreateInstance(type);
             foreach (var item in propertyMappers)
             {
-                object rowField;
-                if (row.TryGetValue(item.Name, out rowField))
+                if (row.TryGetValue(item.Name, out var rowField))
                 {
                     item.Mapper(rowField, obj);
                 }

--- a/src/Trafi.BigQuerier/Mapper/Value.cs
+++ b/src/Trafi.BigQuerier/Mapper/Value.cs
@@ -10,482 +10,481 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Trafi.BigQuerier.Mapper
+namespace Trafi.BigQuerier.Mapper;
+
+public static class Value
 {
-    public static class Value
+    public class FieldOptions
     {
-        public class FieldOptions
+        public BigQueryDbType Type;
+        public BigQueryFieldMode Mode;
+
+        public FieldOptions(
+            BigQueryDbType type,
+            BigQueryFieldMode mode
+        )
         {
-            public BigQueryDbType Type;
-            public BigQueryFieldMode Mode;
-
-            public FieldOptions(
-                BigQueryDbType type,
-                BigQueryFieldMode mode
-            )
-            {
-                this.Type = type;
-                this.Mode = mode;
-            }
-        };
-
-        public static FieldOptions? MaybeSimpleFieldOptionsFromType(Type type)
-        {
-            if (type == typeof(string))
-            {
-                return new FieldOptions(
-                    type: BigQueryDbType.String,
-                    mode: BigQueryFieldMode.Nullable
-                );
-            }
-            else if (type == typeof(long))
-            {
-                return new FieldOptions(
-                    type: BigQueryDbType.Int64,
-                    mode: BigQueryFieldMode.Nullable
-                );
-            }
-            else if (type == typeof(long?))
-            {
-                return new FieldOptions(
-                    type: BigQueryDbType.Int64,
-                    mode: BigQueryFieldMode.Nullable
-                );
-            }
-            else if (type == typeof(int))
-            {
-                return new FieldOptions(
-                    type: BigQueryDbType.Int64,
-                    mode: BigQueryFieldMode.Nullable
-                );
-            }
-            else if (type == typeof(int?))
-            {
-                return new FieldOptions(
-                    type: BigQueryDbType.Int64,
-                    mode: BigQueryFieldMode.Nullable
-                );
-            }
-            else if (type == typeof(double))
-            {
-                return new FieldOptions(
-                    type: BigQueryDbType.Float64,
-                    mode: BigQueryFieldMode.Nullable
-                );
-            }
-            else if (type == typeof(double?))
-            {
-                return new FieldOptions(
-                    type: BigQueryDbType.Float64,
-                    mode: BigQueryFieldMode.Nullable
-                );
-            }
-            else if (type == typeof(bool))
-            {
-                return new FieldOptions(
-                    type: BigQueryDbType.Bool,
-                    mode: BigQueryFieldMode.Nullable
-                );
-            }
-            else if (type == typeof(bool?))
-            {
-                return new FieldOptions(
-                    type: BigQueryDbType.Bool,
-                    mode: BigQueryFieldMode.Nullable
-                );
-            }
-            else if (type == typeof(DateTime))
-            {
-                return new FieldOptions(
-                    type: BigQueryDbType.Timestamp,
-                    mode: BigQueryFieldMode.Nullable
-                );
-            }
-            else if (type == typeof(DateTime?))
-            {
-                return new FieldOptions(
-                    type: BigQueryDbType.Timestamp,
-                    mode: BigQueryFieldMode.Nullable
-                );
-            }
-
-            return null;
+            this.Type = type;
+            this.Mode = mode;
         }
-        
-        #nullable disable
+    };
 
-        public static Func<object, object> MaybeFieldToBigQueryFunction(Type type)
+    public static FieldOptions? MaybeSimpleFieldOptionsFromType(Type type)
+    {
+        if (type == typeof(string))
         {
-            if (type == typeof(string))
-            {
-                return v => v;
-            }
-            else if (type == typeof(long))
-            {
-                return v => v;
-            }
-            else if (type == typeof(long?))
-            {
-                return v => v;
-            }
-            else if (type == typeof(int))
-            {
-                return v => (long)(int)v;
-            }
-            else if (type == typeof(int?))
-            {
-                return v => (long?)(int?)v;
-            }
-            else if (type == typeof(double))
-            {
-                return v => v;
-            }
-            else if (type == typeof(double?))
-            {
-                return v => v;
-            }
-            else if (type == typeof(bool))
-            {
-                return v => v;
-            }
-            else if (type == typeof(bool?))
-            {
-                return v => v;
-            }
-            else if (type == typeof(DateTime))
-            {
-                return v => v;
-            }
-            else if (type == typeof(DateTime?))
-            {
-                return v => v;
-            }
-
-            return null;
+            return new FieldOptions(
+                type: BigQueryDbType.String,
+                mode: BigQueryFieldMode.Nullable
+            );
+        }
+        else if (type == typeof(long))
+        {
+            return new FieldOptions(
+                type: BigQueryDbType.Int64,
+                mode: BigQueryFieldMode.Nullable
+            );
+        }
+        else if (type == typeof(long?))
+        {
+            return new FieldOptions(
+                type: BigQueryDbType.Int64,
+                mode: BigQueryFieldMode.Nullable
+            );
+        }
+        else if (type == typeof(int))
+        {
+            return new FieldOptions(
+                type: BigQueryDbType.Int64,
+                mode: BigQueryFieldMode.Nullable
+            );
+        }
+        else if (type == typeof(int?))
+        {
+            return new FieldOptions(
+                type: BigQueryDbType.Int64,
+                mode: BigQueryFieldMode.Nullable
+            );
+        }
+        else if (type == typeof(double))
+        {
+            return new FieldOptions(
+                type: BigQueryDbType.Float64,
+                mode: BigQueryFieldMode.Nullable
+            );
+        }
+        else if (type == typeof(double?))
+        {
+            return new FieldOptions(
+                type: BigQueryDbType.Float64,
+                mode: BigQueryFieldMode.Nullable
+            );
+        }
+        else if (type == typeof(bool))
+        {
+            return new FieldOptions(
+                type: BigQueryDbType.Bool,
+                mode: BigQueryFieldMode.Nullable
+            );
+        }
+        else if (type == typeof(bool?))
+        {
+            return new FieldOptions(
+                type: BigQueryDbType.Bool,
+                mode: BigQueryFieldMode.Nullable
+            );
+        }
+        else if (type == typeof(DateTime))
+        {
+            return new FieldOptions(
+                type: BigQueryDbType.Timestamp,
+                mode: BigQueryFieldMode.Nullable
+            );
+        }
+        else if (type == typeof(DateTime?))
+        {
+            return new FieldOptions(
+                type: BigQueryDbType.Timestamp,
+                mode: BigQueryFieldMode.Nullable
+            );
         }
 
-        public struct MapResult
+        return null;
+    }
+
+#nullable disable
+
+    public static Func<object, object> MaybeFieldToBigQueryFunction(Type type)
+    {
+        if (type == typeof(string))
         {
-            public object Value;
-            public bool Skip;
+            return v => v;
+        }
+        else if (type == typeof(long))
+        {
+            return v => v;
+        }
+        else if (type == typeof(long?))
+        {
+            return v => v;
+        }
+        else if (type == typeof(int))
+        {
+            return v => (long)(int)v;
+        }
+        else if (type == typeof(int?))
+        {
+            return v => (long?)(int?)v;
+        }
+        else if (type == typeof(double))
+        {
+            return v => v;
+        }
+        else if (type == typeof(double?))
+        {
+            return v => v;
+        }
+        else if (type == typeof(bool))
+        {
+            return v => v;
+        }
+        else if (type == typeof(bool?))
+        {
+            return v => v;
+        }
+        else if (type == typeof(DateTime))
+        {
+            return v => v;
+        }
+        else if (type == typeof(DateTime?))
+        {
+            return v => v;
         }
 
-        private static Func<object, MapResult> TryCastLongToIntFunction()
-        {
-            return o => o is long l && l <= int.MaxValue 
-                    ? new MapResult { Value = (int)l }
-                    : new MapResult { Skip = true };
-        }
+        return null;
+    }
 
-        private static Func<object, MapResult> TryCastLongToIntNullableFunction()
-        {
-            return o => o is long l && l <= int.MaxValue
-                ? new MapResult { Value = (int?)l }
-                : o == null 
-                  ? new MapResult { Value = null }
-                  : new MapResult { Skip = true };
-        }
+    public struct MapResult
+    {
+        public object Value;
+        public bool Skip;
+    }
 
-        private static Func<object, MapResult> DirectMapIfTypeFunction<T>()
+    private static Func<object, MapResult> TryCastLongToIntFunction()
+    {
+        return o => o is long l && l <= int.MaxValue
+            ? new MapResult { Value = (int)l }
+            : new MapResult { Skip = true };
+    }
+
+    private static Func<object, MapResult> TryCastLongToIntNullableFunction()
+    {
+        return o => o is long l && l <= int.MaxValue
+            ? new MapResult { Value = (int?)l }
+            : o == null
+                ? new MapResult { Value = null }
+                : new MapResult { Skip = true };
+    }
+
+    private static Func<object, MapResult> DirectMapIfTypeFunction<T>()
+    {
+        return o => o is T
+            ? new MapResult { Value = (T)o }
+            : new MapResult { Skip = true };
+    }
+
+    public static Func<object, MapResult> MaybeFieldFromBigQueryFunction(Type type)
+    {
+        if (type == typeof(string))
         {
-            return o => o is T
-                ? new MapResult { Value = (T)o }
+            return DirectMapIfTypeFunction<string>();
+        }
+        else if (type == typeof(long))
+        {
+            return DirectMapIfTypeFunction<long>();
+        }
+        else if (type == typeof(long?))
+        {
+            return DirectMapIfTypeFunction<long?>();
+        }
+        else if (type == typeof(int))
+        {
+            return TryCastLongToIntFunction();
+        }
+        else if (type == typeof(int?))
+        {
+            return TryCastLongToIntNullableFunction();
+        }
+        else if (type == typeof(double))
+        {
+            return o => o is double
+                ? new MapResult { Value = o as double? }
+                : new MapResult { Skip = true };
+        }
+        else if (type == typeof(double?))
+        {
+            return o => o is double
+                ? new MapResult { Value = o as double? }
+                : new MapResult { Skip = true };
+        }
+        else if (type == typeof(bool))
+        {
+            return o => o is bool
+                ? new MapResult { Value = o as bool? }
+                : new MapResult { Skip = true };
+        }
+        else if (type == typeof(bool?))
+        {
+            return o => o is bool
+                ? new MapResult { Value = o as bool? }
+                : new MapResult { Skip = true };
+        }
+        else if (type == typeof(DateTime))
+        {
+            return o => o is DateTime
+                ? new MapResult { Value = o as DateTime? }
+                : new MapResult { Skip = true };
+        }
+        else if (type == typeof(DateTime?))
+        {
+            return o => o is DateTime
+                ? new MapResult { Value = o as DateTime? }
                 : new MapResult { Skip = true };
         }
 
-        public static Func<object, MapResult> MaybeFieldFromBigQueryFunction(Type type)
-        {
-            if (type == typeof(string))
-            {
-                return DirectMapIfTypeFunction<string>();
-            }
-            else if (type == typeof(long))
-            {
-                return DirectMapIfTypeFunction<long>();
-            }
-            else if (type == typeof(long?))
-            {
-                return DirectMapIfTypeFunction<long?>();
-            }
-            else if (type == typeof(int))
-            {
-                return TryCastLongToIntFunction();
-            }
-            else if (type == typeof(int?))
-            {
-                return TryCastLongToIntNullableFunction();
-            }
-            else if (type == typeof(double))
-            {
-                return o => o is double
-                    ? new MapResult { Value = o as double? }
-                    : new MapResult { Skip = true };
-            }
-            else if (type == typeof(double?))
-            {
-                return o => o is double
-                    ? new MapResult { Value = o as double? }
-                    : new MapResult { Skip = true };
-            }
-            else if (type == typeof(bool))
-            {
-                return o => o is bool
-                    ? new MapResult { Value = o as bool? }
-                    : new MapResult { Skip = true };
-            }
-            else if (type == typeof(bool?))
-            {
-                return o => o is bool
-                    ? new MapResult { Value = o as bool? }
-                    : new MapResult { Skip = true };
-            }
-            else if (type == typeof(DateTime))
-            {
-                return o => o is DateTime
-                    ? new MapResult { Value = o as DateTime? }
-                    : new MapResult { Skip = true };
-            }
-            else if (type == typeof(DateTime?))
-            {
-                return o => o is DateTime
-                    ? new MapResult { Value = o as DateTime? }
-                    : new MapResult { Skip = true };
-            }
-
-            return null;
-        }
-
-        public static Func<object, object> MaybeRepeatedFieldToBigQueryFunction(Type type)
-        {
-            if (type.IsArray)
-            {
-                var elementType = type.GetElementType();
-                if (Record.IsContractType(elementType))
-                {
-                    var elementMapFunction = Record.GetValueToBigQueryFunction(elementType);
-                    return value => ArrayValueToBigQuery<BigQueryInsertRow>(value, elementMapFunction);
-                }
-                else
-                {
-                    var elementMapFunction = MaybeFieldToBigQueryFunction(elementType);
-
-                    if (elementType == typeof(string))
-                    {
-                        return value => ArrayValueToBigQuery<string>(value, elementMapFunction);
-                    }
-                    else if (elementType == typeof(long))
-                    {
-                        return value => ArrayValueToBigQuery<long>(value, elementMapFunction);
-                    }
-                    else if (elementType == typeof(long?))
-                    {
-                        return value => ArrayValueToBigQuery<long?>(value, elementMapFunction);
-                    }
-                    else if (elementType == typeof(int))
-                    {
-                        return value => ArrayValueToBigQuery<long>(value, elementMapFunction);
-                    }
-                    else if (elementType == typeof(int?))
-                    {
-                        return value => ArrayValueToBigQuery<long?>(value, elementMapFunction);
-                    }
-                    else if (elementType == typeof(double))
-                    {
-                        return value => ArrayValueToBigQuery<double>(value, elementMapFunction);
-                    }
-                    else if (elementType == typeof(double?))
-                    {
-                        return value => ArrayValueToBigQuery<double?>(value, elementMapFunction);
-                    }
-                    else if (elementType == typeof(bool))
-                    {
-                        return value => ArrayValueToBigQuery<bool>(value, elementMapFunction);
-                    }
-                    else if (elementType == typeof(bool?))
-                    {
-                        return value => ArrayValueToBigQuery<bool?>(value, elementMapFunction);
-                    }
-                    else if (elementType == typeof(DateTime))
-                    {
-                        return value => ArrayValueToBigQuery<DateTime>(value, elementMapFunction);
-                    }
-                    else if (elementType == typeof(DateTime?))
-                    {
-                        return value => ArrayValueToBigQuery<DateTime?>(value, elementMapFunction);
-                    }
-                }
-            }
-
-            return null;
-        }
-
-        public static Func<object, MapResult> MaybeRepeatedFieldFromBigQueryFunction(Type type)
-        {
-            if (type.IsArray)
-            {
-                var elementType = type.GetElementType();
-                if (Record.IsContractType(elementType))
-                {
-                    var elementMapFunction = Record.GetValueFromBigQueryDictionaryFunction(elementType);
-                    return value => {
-                        if (value == null)
-                        {
-                            return new MapResult { Value = Array.CreateInstance(elementType, 0), Skip = false };
-                        }
-
-                        var list = (Dictionary<string, object>[])value;
-                        var mapped = list
-                            .Select(elementMapFunction)
-                            .ToArray();
-                        var array = Array.CreateInstance(elementType, mapped.Length);
-                        Array.Copy(mapped, array, mapped.Length);
-
-                        return new MapResult { Value = array, Skip = false };
-                    };
-                }
-                else
-                {
-                    var elementMapFunction = MaybeFieldFromBigQueryFunction(elementType);
-                    if (elementType == typeof(string))
-                    {
-                        return value => NullableClassArrayValueFromBigQuery<string>(value, elementMapFunction);
-                    }
-                    else if (elementType == typeof(long))
-                    {
-                        return value => PrimitiveArrayValueFromBigQuery<long>(value, elementMapFunction);
-                    }
-                    else if (elementType == typeof(long?))
-                    {
-                        return value => NullablePrimitiveArrayValueFromBigQuery<long>(value, elementMapFunction);
-                    }
-                    else if (elementType == typeof(int))
-                    {
-                        return value => IntegerArrayValueFromBigQuery(value, elementMapFunction);
-                    }
-                    else if (elementType == typeof(int?))
-                    {
-                        return value => NullableIntegerArrayValueFromBigQuery(value, elementMapFunction);
-                    }
-                    else if (elementType == typeof(double))
-                    {
-                        return value => PrimitiveArrayValueFromBigQuery<double>(value, elementMapFunction);
-                    }
-                    else if (elementType == typeof(double?))
-                    {
-                        return value => NullablePrimitiveArrayValueFromBigQuery<double>(value, elementMapFunction);
-                    }
-                    else if (elementType == typeof(bool))
-                    {
-                        return value => PrimitiveArrayValueFromBigQuery<bool>(value, elementMapFunction);
-                    }
-                    else if (elementType == typeof(bool?))
-                    {
-                        return value => NullablePrimitiveArrayValueFromBigQuery<bool>(value, elementMapFunction);
-                    }
-                    else if (elementType == typeof(DateTime))
-                    {
-                        return value => PrimitiveArrayValueFromBigQuery<DateTime>(value, elementMapFunction);
-                    }
-                    else if (elementType == typeof(DateTime?))
-                    {
-                        return value => NullablePrimitiveArrayValueFromBigQuery<DateTime>(value, elementMapFunction);
-                    }
-                }
-            }
-
-            return null;
-        }
-
-        private static T[] ArrayValueToBigQuery<T>(object value, Func<object, object> valueToBigQueryFunction)
-        {
-            if (value == null) return new T[0];
-
-            var array = (Array)value;
-            var rows = new List<T>(array.Length);
-            foreach (var element in array)
-            {
-                rows.Add((T)valueToBigQueryFunction(element));
-            }
-            return rows.ToArray();
-        }
-
-        private static MapResult PrimitiveArrayValueFromBigQuery<T>(object value, Func<object, MapResult> elementMapFunction) where T: struct
-        {
-            if (!(value is T[])) return new MapResult { Skip = true };
-            var array = value as T[];
-            if (array == null) return new MapResult { Value = new T[0] };
-
-            return new MapResult
-            {
-                Value = array
-                    .Select(i => elementMapFunction(i))
-                    .Where(i => !i.Skip)
-                    .Select(i => (T)i.Value)
-                    .ToArray()
-            };
-        }
-
-        private static MapResult IntegerArrayValueFromBigQuery(object value, Func<object, MapResult> elementMapFunction)
-        {
-            if (!(value is long[])) return new MapResult { Skip = true };
-            var array = value as long[];
-            if (array == null) return new MapResult { Value = new long[0] };
-
-            return new MapResult
-            {
-                Value = array
-                    .Select(i => elementMapFunction(i))
-                    .Where(i => !i.Skip)
-                    .Select(i => (int)i.Value)
-                    .ToArray()
-            };
-        }
-
-        private static MapResult NullablePrimitiveArrayValueFromBigQuery<T>(object value, Func<object, MapResult> elementMapFunction) where T: struct
-        {
-            if (!(value is T?[])) return new MapResult { Skip = true };
-            var array = value as T?[];
-            if (array == null) return new MapResult { Value = new T?[0] };
-
-            return new MapResult
-            {
-                Value = array
-                    .Select(i => elementMapFunction(i))
-                    .Select(i => i.Skip ? null : (T?)i.Value)
-                    .ToArray()
-            };
-        }
-
-        private static MapResult NullableIntegerArrayValueFromBigQuery(object value, Func<object, MapResult> elementMapFunction)
-        {
-            if (!(value is long?[])) return new MapResult { Skip = true };
-            var array = value as long?[];
-            if (array == null) return new MapResult { Value = new long?[0] };
-
-            return new MapResult
-            {
-                Value = array
-                    .Select(i => elementMapFunction(i))
-                    .Select(i => i.Skip ? null : (int?)i.Value)
-                    .ToArray()
-            };
-        }
-
-        private static MapResult NullableClassArrayValueFromBigQuery<T>(object value, Func<object, MapResult> elementMapFunction) where T : class
-        {
-            if (!(value is T[])) return new MapResult { Skip = true };
-            var array = value as T[];
-            if (array == null) return new MapResult { Value = new T[0] };
-
-            return new MapResult
-            {
-                Value = array
-                    .Select(i => elementMapFunction(i))
-                    .Select(i => i.Skip ? null : (T)i.Value)
-                    .ToArray()
-            };
-        }
-        
-        #nullable restore
+        return null;
     }
+
+    public static Func<object, object> MaybeRepeatedFieldToBigQueryFunction(Type type)
+    {
+        if (type.IsArray)
+        {
+            var elementType = type.GetElementType();
+            if (Record.IsContractType(elementType))
+            {
+                var elementMapFunction = Record.GetValueToBigQueryFunction(elementType);
+                return value => ArrayValueToBigQuery<BigQueryInsertRow>(value, elementMapFunction);
+            }
+            else
+            {
+                var elementMapFunction = MaybeFieldToBigQueryFunction(elementType);
+
+                if (elementType == typeof(string))
+                {
+                    return value => ArrayValueToBigQuery<string>(value, elementMapFunction);
+                }
+                else if (elementType == typeof(long))
+                {
+                    return value => ArrayValueToBigQuery<long>(value, elementMapFunction);
+                }
+                else if (elementType == typeof(long?))
+                {
+                    return value => ArrayValueToBigQuery<long?>(value, elementMapFunction);
+                }
+                else if (elementType == typeof(int))
+                {
+                    return value => ArrayValueToBigQuery<long>(value, elementMapFunction);
+                }
+                else if (elementType == typeof(int?))
+                {
+                    return value => ArrayValueToBigQuery<long?>(value, elementMapFunction);
+                }
+                else if (elementType == typeof(double))
+                {
+                    return value => ArrayValueToBigQuery<double>(value, elementMapFunction);
+                }
+                else if (elementType == typeof(double?))
+                {
+                    return value => ArrayValueToBigQuery<double?>(value, elementMapFunction);
+                }
+                else if (elementType == typeof(bool))
+                {
+                    return value => ArrayValueToBigQuery<bool>(value, elementMapFunction);
+                }
+                else if (elementType == typeof(bool?))
+                {
+                    return value => ArrayValueToBigQuery<bool?>(value, elementMapFunction);
+                }
+                else if (elementType == typeof(DateTime))
+                {
+                    return value => ArrayValueToBigQuery<DateTime>(value, elementMapFunction);
+                }
+                else if (elementType == typeof(DateTime?))
+                {
+                    return value => ArrayValueToBigQuery<DateTime?>(value, elementMapFunction);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    public static Func<object, MapResult> MaybeRepeatedFieldFromBigQueryFunction(Type type)
+    {
+        if (type.IsArray)
+        {
+            var elementType = type.GetElementType();
+            if (Record.IsContractType(elementType))
+            {
+                var elementMapFunction = Record.GetValueFromBigQueryDictionaryFunction(elementType);
+                return value => {
+                    if (value == null)
+                    {
+                        return new MapResult { Value = Array.CreateInstance(elementType, 0), Skip = false };
+                    }
+
+                    var list = (Dictionary<string, object>[])value;
+                    var mapped = list
+                        .Select(elementMapFunction)
+                        .ToArray();
+                    var array = Array.CreateInstance(elementType, mapped.Length);
+                    Array.Copy(mapped, array, mapped.Length);
+
+                    return new MapResult { Value = array, Skip = false };
+                };
+            }
+            else
+            {
+                var elementMapFunction = MaybeFieldFromBigQueryFunction(elementType);
+                if (elementType == typeof(string))
+                {
+                    return value => NullableClassArrayValueFromBigQuery<string>(value, elementMapFunction);
+                }
+                else if (elementType == typeof(long))
+                {
+                    return value => PrimitiveArrayValueFromBigQuery<long>(value, elementMapFunction);
+                }
+                else if (elementType == typeof(long?))
+                {
+                    return value => NullablePrimitiveArrayValueFromBigQuery<long>(value, elementMapFunction);
+                }
+                else if (elementType == typeof(int))
+                {
+                    return value => IntegerArrayValueFromBigQuery(value, elementMapFunction);
+                }
+                else if (elementType == typeof(int?))
+                {
+                    return value => NullableIntegerArrayValueFromBigQuery(value, elementMapFunction);
+                }
+                else if (elementType == typeof(double))
+                {
+                    return value => PrimitiveArrayValueFromBigQuery<double>(value, elementMapFunction);
+                }
+                else if (elementType == typeof(double?))
+                {
+                    return value => NullablePrimitiveArrayValueFromBigQuery<double>(value, elementMapFunction);
+                }
+                else if (elementType == typeof(bool))
+                {
+                    return value => PrimitiveArrayValueFromBigQuery<bool>(value, elementMapFunction);
+                }
+                else if (elementType == typeof(bool?))
+                {
+                    return value => NullablePrimitiveArrayValueFromBigQuery<bool>(value, elementMapFunction);
+                }
+                else if (elementType == typeof(DateTime))
+                {
+                    return value => PrimitiveArrayValueFromBigQuery<DateTime>(value, elementMapFunction);
+                }
+                else if (elementType == typeof(DateTime?))
+                {
+                    return value => NullablePrimitiveArrayValueFromBigQuery<DateTime>(value, elementMapFunction);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static T[] ArrayValueToBigQuery<T>(object value, Func<object, object> valueToBigQueryFunction)
+    {
+        if (value == null) return new T[0];
+
+        var array = (Array)value;
+        var rows = new List<T>(array.Length);
+        foreach (var element in array)
+        {
+            rows.Add((T)valueToBigQueryFunction(element));
+        }
+        return rows.ToArray();
+    }
+
+    private static MapResult PrimitiveArrayValueFromBigQuery<T>(object value, Func<object, MapResult> elementMapFunction) where T: struct
+    {
+        if (!(value is T[])) return new MapResult { Skip = true };
+        var array = value as T[];
+        if (array == null) return new MapResult { Value = new T[0] };
+
+        return new MapResult
+        {
+            Value = array
+                .Select(i => elementMapFunction(i))
+                .Where(i => !i.Skip)
+                .Select(i => (T)i.Value)
+                .ToArray()
+        };
+    }
+
+    private static MapResult IntegerArrayValueFromBigQuery(object value, Func<object, MapResult> elementMapFunction)
+    {
+        if (!(value is long[])) return new MapResult { Skip = true };
+        var array = value as long[];
+        if (array == null) return new MapResult { Value = new long[0] };
+
+        return new MapResult
+        {
+            Value = array
+                .Select(i => elementMapFunction(i))
+                .Where(i => !i.Skip)
+                .Select(i => (int)i.Value)
+                .ToArray()
+        };
+    }
+
+    private static MapResult NullablePrimitiveArrayValueFromBigQuery<T>(object value, Func<object, MapResult> elementMapFunction) where T: struct
+    {
+        if (!(value is T?[])) return new MapResult { Skip = true };
+        var array = value as T?[];
+        if (array == null) return new MapResult { Value = new T?[0] };
+
+        return new MapResult
+        {
+            Value = array
+                .Select(i => elementMapFunction(i))
+                .Select(i => i.Skip ? null : (T?)i.Value)
+                .ToArray()
+        };
+    }
+
+    private static MapResult NullableIntegerArrayValueFromBigQuery(object value, Func<object, MapResult> elementMapFunction)
+    {
+        if (!(value is long?[])) return new MapResult { Skip = true };
+        var array = value as long?[];
+        if (array == null) return new MapResult { Value = new long?[0] };
+
+        return new MapResult
+        {
+            Value = array
+                .Select(i => elementMapFunction(i))
+                .Select(i => i.Skip ? null : (int?)i.Value)
+                .ToArray()
+        };
+    }
+
+    private static MapResult NullableClassArrayValueFromBigQuery<T>(object value, Func<object, MapResult> elementMapFunction) where T : class
+    {
+        if (!(value is T[])) return new MapResult { Skip = true };
+        var array = value as T[];
+        if (array == null) return new MapResult { Value = new T[0] };
+
+        return new MapResult
+        {
+            Value = array
+                .Select(i => elementMapFunction(i))
+                .Select(i => i.Skip ? null : (T)i.Value)
+                .ToArray()
+        };
+    }
+
+#nullable restore
 }

--- a/src/Trafi.BigQuerier/QuerierContract.cs
+++ b/src/Trafi.BigQuerier/QuerierContract.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 
-namespace Trafi.BigQuerier
+namespace Trafi.BigQuerier;
+
+[AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+public class QuerierContract : Attribute
 {
-    [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
-    public class QuerierContract : Attribute
-    {
-    }
 }

--- a/src/Trafi.BigQuerier/Trafi.BigQuerier.csproj
+++ b/src/Trafi.BigQuerier/Trafi.BigQuerier.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>    
-    <TargetFramework>net6.0</TargetFramework>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>CS8600;CS8604;CS8602;CS8625;CS8632;CS8603;CS8618;CS8619;CS8767;CS8613;CS8601;CS8620</WarningsAsErrors>
@@ -29,5 +29,9 @@
   <ItemGroup>
     <PackageReference Include="Google.Apis.Auth" Version="1.54.0" />
     <PackageReference Include="Google.Cloud.BigQuery.V2" Version="2.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Trafi.BigQuerier.Tests" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Fix a bug with two separate queues where a queue size limit was placed on a wrong queue and `_storageQueue` would fill up beyond a `1_000_000` items
- Enable concurrent batch submitting to BigQuery

Video of a stress test LINQPad script. The input field defines how many records get inserted per second. Theoretical limit of given configuration is ~3860 inserts per second but due to timings and coordination practically ~3600 can be handled without growing the backlog. First parameter in the insert-log-message is concurrency count so `[5]` would mean that this log message was submitted by a 5th concurrent instance of dispatch to BigQuery.

https://github.com/user-attachments/assets/b8a6640f-21ab-4d6d-af03-c9cf63ba4bbb
